### PR TITLE
Add main function deployment workflow

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -1,0 +1,54 @@
+name: Deploy Main Function
+permissions:
+  id-token: write
+  contents: read
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  deploy:
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+    environment: prod
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup .NET 9 SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Downgrade Azure CLI to 2.72.0
+        run: |
+          echo "Downgrading Azure CLI to version 2.72.0 to work around response consumption bug"
+          pip install azure-cli==2.72.0
+          az version
+
+      - uses: azure/login@v1
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Get Function App Name
+        id: get-func
+        run: |
+          FUNCTION_APP_NAME=$(az functionapp list \
+              --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
+              --query "[?contains(name, '-pr-')==\`false\`].name | [0]" -o tsv)
+          echo "FUNCTION_APP_NAME=${FUNCTION_APP_NAME}" >> $GITHUB_ENV
+          echo "Function app name: ${FUNCTION_APP_NAME}"
+
+      - name: Install Azure Functions Core Tools
+        run: npm install -g azure-functions-core-tools@4 --unsafe-perm true
+
+      - name: Publish Function Code
+        run: |
+          pushd src/MovieTracker.Backend
+          func azure functionapp publish ${FUNCTION_APP_NAME} \
+            --dotnet-isolated \
+            --nozip
+          popd
+

--- a/Readme.md
+++ b/Readme.md
@@ -70,6 +70,10 @@ You can optionally set a repository variable named `DEPLOY_PAUSE_SECONDS` to con
 
 Once configured, pushes to a PR will automatically deploy and update an isolated function app. Closing the PR triggers the cleanup job to remove the temporary resources.
 
+### Production Deployment
+The `deploy-main.yml` workflow runs when a pull request targeting the `main` branch is merged. It publishes the updated code to the existing production function app without recreating infrastructure.
+
+
 
 
 ## How to Use


### PR DESCRIPTION
## Summary
- deploy to existing function when PR merges to `main`
- document production deployment workflow

## Testing
- `dotnet build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684a189d9da48331a8e064683fb91b22