### PR TITLE
integrate Open Movie Db Agent for comprehensive movie ratings

### DIFF
--- a/src/MovieTracker.Backend/Agents/OpenMovieDbAgent.cs
+++ b/src/MovieTracker.Backend/Agents/OpenMovieDbAgent.cs
@@ -1,0 +1,135 @@
+﻿using Microsoft.Extensions.Configuration;
+using OMDbApiNet;
+using OMDbApiNet.Model;
+
+namespace MovieTracker.Backend.Agents
+{
+    public record MovieRatingResult(
+        string Title,
+        string Year,
+        string ImdbRating,
+        string RottenTomatoesRating,
+        string MetacriticRating,
+        string BoxOffice,
+        bool IsSuccess,
+        string ErrorMessage = ""
+    );
+
+    public record RatingComparisonResult(
+        string HighestRatedTitle,
+        string HighestRating,
+        List<MovieRatingResult> AllMovies,
+        bool IsSuccess,
+        string ErrorMessage = ""
+    );
+
+    public class OpenMovieDbAgent
+    {
+        private readonly AsyncOmdbClient omdbClient;
+
+        public OpenMovieDbAgent(IConfiguration configuration)
+        {
+           var apiKey = configuration["OpenMovieDb:Api-Key"] ?? throw new ArgumentNullException("Missing OMDb Api Key");
+
+           omdbClient = new AsyncOmdbClient(apiKey);
+        }
+
+        public async Task<MovieRatingResult> GetMovieRatings(string imdbId)
+        {
+            try
+            {
+                var movie = await omdbClient.GetItemByIdAsync(imdbId);
+
+                if (movie.Response == "False")
+                {
+                    return new MovieRatingResult("", "", "", "", "", "", false, $"Movie not found for IMDb ID: {imdbId}");
+                }
+
+                var ratings = movie.Ratings;
+
+                return new MovieRatingResult(
+                    Title: movie.Title ?? "",
+                    Year: movie.Year ?? "",
+                    ImdbRating: movie.ImdbRating ?? "N/A",
+                    RottenTomatoesRating: GetRatingBySource(ratings, "Rotten Tomatoes"),
+                    MetacriticRating: GetRatingBySource(ratings, "Metacritic"),
+                    BoxOffice: movie.BoxOffice ?? "N/A",
+                    IsSuccess: true
+                );
+            }
+            catch (Exception ex)
+            {
+                return new MovieRatingResult("", "", "", "", "", "", false, $"Error: {ex.Message}");
+            }
+        }
+
+        public async Task<RatingComparisonResult> CompareMovieRatings(List<string> imdbIds)
+        {
+            try
+            {
+                var movieRatings = new List<MovieRatingResult>();
+
+                foreach (var id in imdbIds)
+                {
+                    var rating = await GetMovieRatings(id);
+                    if (rating.IsSuccess)
+                    {
+                        movieRatings.Add(rating);
+                    }
+                }
+
+                if (!movieRatings.Any())
+                {
+                    return new RatingComparisonResult("", "", new List<MovieRatingResult>(), false, "No valid movies found for comparison");
+                }
+
+                var highest = movieRatings
+                    .Where(m => double.TryParse(m.ImdbRating, out _))
+                    .OrderByDescending(m => double.Parse(m.ImdbRating))
+                    .FirstOrDefault();
+
+                if (highest == null)
+                {
+                    return new RatingComparisonResult("", "", movieRatings, false, "No movies with valid IMDb ratings found");
+                }
+
+                return new RatingComparisonResult(
+                    HighestRatedTitle: $"{highest.Title} ({highest.Year})",
+                    HighestRating: highest.ImdbRating,
+                    AllMovies: movieRatings,
+                    IsSuccess: true
+                );
+            }
+            catch (Exception ex)
+            {
+                return new RatingComparisonResult("", "", new List<MovieRatingResult>(), false, $"Error: {ex.Message}");
+            }
+        }
+
+        public async Task<List<MovieRatingResult>> FilterMoviesByRating(List<string> imdbIds, double minimumRating)
+        {
+            var qualifyingMovies = new List<MovieRatingResult>();
+
+            foreach (var id in imdbIds)
+            {
+                var rating = await GetMovieRatings(id);
+                if (rating.IsSuccess &&
+                    double.TryParse(rating.ImdbRating, out double actualRating) &&
+                    actualRating >= minimumRating)
+                {
+                    qualifyingMovies.Add(rating);
+                }
+            }
+
+            return qualifyingMovies;
+        }
+
+        private static string GetRatingBySource(List<Rating> ratings, string sourceName)
+        {
+            if (ratings == null) return "N/A";
+
+            var rating = ratings.FirstOrDefault(r => r.Source.Contains(sourceName, StringComparison.OrdinalIgnoreCase));
+            return rating?.Value ?? "N/A";
+        }
+    }
+}

--- a/src/MovieTracker.Backend/Agents/WikipediaSearchAgent.cs
+++ b/src/MovieTracker.Backend/Agents/WikipediaSearchAgent.cs
@@ -1,12 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel;
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using System.Text;
 using System.Text.Json;
-using System.Threading.Tasks;
 
 namespace MovieTracker.Backend.Agents
 {

--- a/src/MovieTracker.Backend/MovieTracker.Backend.csproj
+++ b/src/MovieTracker.Backend/MovieTracker.Backend.csproj
@@ -30,6 +30,7 @@
 		<PackageReference Include="Microsoft.SemanticKernel" Version="1.49.0" />
 		<PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.49.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+		<PackageReference Include="OmdbApiNet" Version="1.3.0" />
 		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
 		<PackageReference Include="TMDbLib" Version="2.2.0" />
 	</ItemGroup>

--- a/src/MovieTracker.Backend/Program.cs
+++ b/src/MovieTracker.Backend/Program.cs
@@ -82,6 +82,7 @@ var host = new HostBuilder()
         services.AddScoped<ChatSessionRepository>();
         services.AddHttpClient<WikipediaSearchAgent>();
         services.AddScoped<WikipediaSearchAgent>();
+        services.AddScoped<OpenMovieDbAgent>();
         services.AddScoped<Kernel>(serviceProvider =>
         {
 

--- a/src/MovieTracker.Backend/Prompts/TheMovieDBKernelFunctions.cs
+++ b/src/MovieTracker.Backend/Prompts/TheMovieDBKernelFunctions.cs
@@ -1,33 +1,27 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.SemanticKernel;
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using System.Net.Quic;
-using System.Text;
 using System.Text.Json;
-using System.Threading.Tasks;
 using TMDbLib.Client;
 using TMDbLib.Objects.Discover;
 
 namespace MovieTracker.Backend.Prompts
 {
-    public record MovieSearchResult(string MovieId, string MovieName, string ReleaseDate);
+    public record MovieSearchResult(string MovieId, string MovieName, string ReleaseDate, string ImdbId);
     public record GenresItem(string GenreId, string GenreName);
+
     public class TheMovieDBKernelFunctions(IConfiguration configuration)
     {
         private readonly string apiKey = configuration["TheMovieDb:Api-Key"] ?? throw new ArgumentNullException("Missing The Movice Db Api Key");
         private record MovieItem(string MovieId, string MovieName);
 
-       
         [KernelFunction]
         [Description("Get the list of official genres for movies.")]
         [return: Description("a json list of official genres for movies, with the following properties GenreId and the GenreName")]
         public async Task<string> GetGenresList()
         {
             TMDbClient client = new TMDbClient(apiKey);
-            var genres = await client.GetMovieGenresAsync();  
+            var genres = await client.GetMovieGenresAsync();
             var genresList = genres.Select(g => new GenresItem(g.Id.ToString(), g.Name)).ToList();
             return JsonSerializer.Serialize(genresList);
         }
@@ -40,16 +34,14 @@ namespace MovieTracker.Backend.Prompts
                  [Description("The name of the person or cast member")] string personName)
         {
             TMDbClient client = new TMDbClient(apiKey);
-            var searchResults = await client.SearchPersonAsync(personName,includeAdult:false,region: "en-US");
+            var searchResults = await client.SearchPersonAsync(personName, includeAdult: false, region: "en-US");
             var personSearchResults = searchResults.Results.Select(p => new PersonSearchResult(p.Id.ToString(), p.Name)).ToList();
             return JsonSerializer.Serialize(personSearchResults);
         }
 
-       
-
         [KernelFunction]
         [Description("Search for movies by their title and release year. Use this to find movies, you can search by movie name or part of a movie name")]
-        [return: Description("a json list of movies with the following properties MovieId, MovieName, and ReleaseDate")]
+        [return: Description("a json list of movies with the following properties MovieId, MovieName, ReleaseDate, and ImdbId")]
         public async Task<string> SearchMovies(
             [Description("The title of the movie, or part of the title")] string movieTitle,
             [Description("Optional: The year the movie was released")] string? releaseYear = null)
@@ -58,23 +50,49 @@ namespace MovieTracker.Backend.Prompts
             var yearAsInt = int.Parse(releaseYear ?? "0");
             var searchResults = await client.SearchMovieAsync(movieTitle, year: yearAsInt);
 
-            var movieSearchResults = searchResults.Results
-                .Select(m => new MovieSearchResult(m.Id.ToString(), m.Title, m.ReleaseDate.ToString()))
-                .ToList();
+            var movieSearchResults = new List<MovieSearchResult>();
+
+            foreach (var movie in searchResults.Results)
+            {
+                var externalIds = await client.GetMovieExternalIdsAsync(movie.Id);
+                movieSearchResults.Add(new MovieSearchResult(
+                    movie.Id.ToString(),
+                    movie.Title,
+                    movie.ReleaseDate?.ToString("yyyy-MM-dd") ?? "",
+                    externalIds.ImdbId ?? ""
+                ));
+            }
 
             return JsonSerializer.Serialize(movieSearchResults);
         }
 
         [KernelFunction]
         [Description("Get detailed information about a specific movie by its ID.")]
-        [return: Description("Detailed information about the movie, including title, overview, release date, genres, and runtime.")]
+        [return: Description("Detailed information about the movie, including title, overview, release date, genres, runtime, and ImdbId.")]
         public async Task<string> GetMovieDetails(
         [Description("The ID of the movie")] string movieId)
         {
             TMDbClient client = new TMDbClient(apiKey);
             var movie = await client.GetMovieAsync(int.Parse(movieId));
-            return JsonSerializer.Serialize(movie);
+
+            var movieDetails = new
+            {
+                MovieId = movieId,
+                Title = movie.Title,
+                Overview = movie.Overview,
+                ReleaseDate = movie.ReleaseDate?.ToString("yyyy-MM-dd"),
+                Genres = movie.Genres.Select(g => new { Id = g.Id, Name = g.Name }).ToList(),
+                Runtime = movie.Runtime,
+                VoteAverage = movie.VoteAverage,
+                VoteCount = movie.VoteCount,
+                ImdbId = movie.ImdbId ?? "",
+                PosterPath = movie.PosterPath,
+                BackdropPath = movie.BackdropPath
+            };
+
+            return JsonSerializer.Serialize(movieDetails);
         }
+
         [KernelFunction]
         [Description("Search for keywords related to movies.")]
         [return: Description("A JSON list of keywords with their properties such as KeywordId and Name.")]
@@ -89,7 +107,7 @@ namespace MovieTracker.Backend.Prompts
 
         [KernelFunction]
         [Description("Returns detailed information about a specific movie in a serialized format")]
-        [return: Description("Serialized JSON containing information about a specific movie")]
+        [return: Description("Serialized JSON containing information about a specific movie including ImdbId")]
         public async Task<string> DescribeMovie([Description("The movie ID of a specific movie")] string movieId)
         {
             TMDbClient client = new TMDbClient(apiKey);
@@ -98,6 +116,7 @@ namespace MovieTracker.Backend.Prompts
             // Create an object to hold relevant movie data
             var movieData = new
             {
+                MovieId = movieId,
                 Title = movie.Title,
                 Overview = movie.Overview,
                 ReleaseDate = movie.ReleaseDate?.ToString("yyyy-MM-dd"),
@@ -106,6 +125,7 @@ namespace MovieTracker.Backend.Prompts
                 Tagline = movie.Tagline,
                 Rating = movie.VoteAverage,
                 Language = movie.OriginalLanguage,
+                ImdbId = movie.ImdbId ?? "",
                 Cast = (await client.GetMovieCreditsAsync(movie.Id))?.Cast.Take(5).Select(c => c.Name).ToList() // Top 5 cast members
             };
 
@@ -120,7 +140,7 @@ namespace MovieTracker.Backend.Prompts
 
         [KernelFunction]
         [Description("Discover movies based on various filters and sort options.")]
-        [return: Description("A JSON list of movies with their properties such as MovieId, MovieName, and ReleaseDate.")]
+        [return: Description("A JSON list of movies with their properties such as MovieId, MovieName, ReleaseDate, and ImdbId.")]
         public async Task<string> DiscoverMovies(
           [Description("Optional: Start release date (YYYY-MM-DD)")] string? releaseDateFrom = null,
           [Description("Optional: End release date (YYYY-MM-DD)")] string? releaseDateTo = null,
@@ -193,21 +213,22 @@ namespace MovieTracker.Backend.Prompts
                 query = query.WhereVoteCountIsAtMost(maxVoteCount.Value);
             }
 
-            // Apply sort criteria
-            //if (!string.IsNullOrEmpty(sortBy))
-            //{
-            //    query = query.OrderBy((DiscoverMovieSortBy)Enum.Parse(typeof(DiscoverMovieSortBy), sortBy, true));
-            //}
-          
-           
-       
-            // Execute query and format results
+            // Execute query and get results with IMDb IDs
             var searchResults = await query.Query();
-            var movieList = searchResults.Results.Select(m => new MovieSearchResult(m.Id.ToString(), m.Title, m.ReleaseDate.ToString())).ToList();
+            var movieList = new List<MovieSearchResult>();
+
+            foreach (var movie in searchResults.Results)
+            {
+                var externalIds = await client.GetMovieExternalIdsAsync(movie.Id);
+                movieList.Add(new MovieSearchResult(
+                    movie.Id.ToString(),
+                    movie.Title,
+                    movie.ReleaseDate?.ToString("yyyy-MM-dd") ?? "",
+                    externalIds.ImdbId ?? ""
+                ));
+            }
 
             return JsonSerializer.Serialize(movieList);
         }
-
-
     }
 }


### PR DESCRIPTION
- Add OpenMovieDbAgent using OmdbApiNet package for IMDb/RT/Metacritic ratings
- Update ChatPlanner with rating functions (GetMovieRating, CompareMovieRatings, FilterMoviesByRating)
- Register agent in DI and integrate with kernel plugins
- Enables queries: 'IMDb rating for Inception', 'highest rated Godfather movie', 'filter by 7.0+ rating'
- Uses OMDb API key for external rating data enrichment"