### PR TITLE
Migrate from Semantic Kernel to Microsoft Agent Framework

### DIFF
--- a/AGENT_FRAMEWORK_MIGRATION.md
+++ b/AGENT_FRAMEWORK_MIGRATION.md
@@ -1,0 +1,301 @@
+# AGENT_FRAMEWORK_MIGRATION.md — Migrating a .NET App from Microsoft Semantic Kernel to Microsoft Agent Framework
+
+> **Purpose:** Reference/instruction document for an AI coding agent (Claude Code) to perform a real Semantic Kernel → Microsoft Agent Framework migration in a .NET (possibly F#/.NET 10) codebase. Verified against Microsoft docs, the `microsoft/agent-framework` repo, NuGet, and Microsoft DevBlogs current to **July 2026**. Agent Framework .NET latest stable: **`Microsoft.Agents.AI` 1.15.0** (confirmed on NuGet Gallery). Preview-only and fast-changing areas are flagged inline.
+
+## TL;DR
+- **Microsoft Agent Framework (MAF) is the GA successor to both Semantic Kernel (SK) and AutoGen.** It reached **1.0 GA on April 3, 2026** ("we're thrilled to announce that Microsoft Agent Framework has reached version 1.0 for both .NET and Python. This is the production-ready release: stable APIs, and a commitment to long-term support" — Shawn Henry, MAF devblog). Microsoft calls it "Semantic Kernel v2.0 (it's built by the same team!)" and commits to supporting **SK v1.x with critical bug and security fixes for at least one year after MAF GA** — so migrate deliberately, not in a panic.
+- **The migration is mostly mechanical:** `Kernel` + `ChatCompletionAgent` collapse into a single `AIAgent` created via `chatClient.AsAIAgent(...)`; `[KernelFunction]` plugins become `AIFunctionFactory.Create(...)` tools; `AgentGroupChat`/SK orchestration becomes graph-based **Workflows**; options move from `PromptExecutionSettings`/`KernelArguments` to `ChatOptions`. **Critical:** a post-preview rename means you must emit the **new** names — `AgentSession` (not `AgentThread`), `CreateSessionAsync()` (not `GetNewThread()`), and the `session` parameter (not `thread`).
+- **MAF and SK coexist in one solution, so migrate incrementally file-by-file.** Known gaps to plan around: SK **Process Framework is discontinued** (use Workflows), prompt-template formats (**Handlebars/Liquid/YAML** prompts) are **not ported**, and **F# works but needs care** around attributes, records, and async interop.
+
+## Key Findings
+1. **Status & official guidance.** MAF unifies SK's enterprise foundations with AutoGen's orchestration, layered on `Microsoft.Extensions.AI` (MEAI). GA 1.0 shipped **April 3, 2026** (RC on Feb 19, 2026; public preview Oct 2025). Microsoft's stance: new agent projects start on MAF; stable SK production agents may migrate lazily; all new agentic investment goes to MAF first; AutoGen enters maintenance mode.
+2. **A rename affects every line of state-management code you generate.** The conversation-state type was renamed `AgentThread` → `AgentSession`, creation `GetNewThread()` → `CreateSessionAsync()`, the `RunAsync` parameter `thread` → `session`, and serialization moved onto the agent (`SerializeSessionAsync`/`DeserializeSessionAsync`). Microsoft's auto-generated `/dotnet/api/...` reference pages and many blogs still show the **old** names — the conceptual docs and migration guide show the new ones. Always emit the new names.
+3. **Package remap is clean:** `Microsoft.SemanticKernel.*` → `Microsoft.Agents.AI.*` + `Microsoft.Extensions.AI`.
+4. **Interop is first-class:** existing `[KernelFunction]` methods work as tools with zero changes; SK `KernelFunction` instances can be adapted; SK and MAF packages install side by side.
+5. **Gaps to design around:** Process Framework not carried forward; prompt-template languages not ported; several hosting/declarative/DevUI features preview-only.
+
+## Details
+
+### 1. What MAF is and how it relates to SK / AutoGen
+Microsoft Agent Framework is an open-source (MIT) SDK and runtime for building agents and multi-agent workflows in .NET, Python, and Go. Per the official overview it "combines AutoGen's simple agent abstractions with Semantic Kernel's enterprise features — session-based state management, type safety, middleware, telemetry — and adds graph-based workflows for explicit multi-agent orchestration," and is "the direct successor … the next generation of both Semantic Kernel and AutoGen," built by the same teams on top of MEAI's `IChatClient`.
+
+**Timeline:** introduced October 2025 (public preview) → **Release Candidate February 19, 2026** (API surface stabilized, v1.0 features complete) → **GA 1.0 April 3, 2026** with a long-term-support commitment.
+
+**Support policy** (official "Semantic Kernel and Microsoft Agent Framework" devblog): *"Think of Microsoft Agent Framework as Semantic Kernel v2.0 (it's built by the same team!) … we will continue to support Semantic Kernel v1.x for the foreseeable future. We will continue to address critical bugs, security issues and we'll take some existing Semantic Kernel features to GA … and for at least one year after Microsoft Agent Framework leaves Preview and is Generally Available."* Community migration guidance corroborates: *"SK agent abstractions are supported and will receive critical bug fixes for at least one year after Agent Framework GA."*
+
+**When to migrate:**
+- **New projects →** start on MAF.
+- **Stable SK agents in production →** migrate opportunistically; you have ≥1 year of SK v1.x support. Trigger a full migration when you need MAF-only features (MCP, handoff/magentic orchestration, checkpointing/durability, human-in-the-loop).
+- **Complex SK apps** relying on Process Framework, prompt templates, or deep vector-store/RAG pipelines → stage the move and keep SK where MAF still has gaps.
+
+### 2. NuGet package mapping
+
+| Semantic Kernel package | Agent Framework replacement | Notes |
+|---|---|---|
+| `Microsoft.SemanticKernel` | `Microsoft.Agents.AI` (1.15.0) + `Microsoft.Extensions.AI` (10.4.1) | Core agent abstraction `AIAgent`; message/content types come from MEAI. |
+| `Microsoft.SemanticKernel.Agents.Core` | `Microsoft.Agents.AI` | `ChatClientAgent` / base `AIAgent`. |
+| `Microsoft.SemanticKernel.Agents.OpenAI` | `Microsoft.Agents.AI.OpenAI` | Extensions on `OpenAIClient` / `AzureOpenAIClient`. |
+| `Microsoft.SemanticKernel.Agents.AzureAI` | `Microsoft.Agents.AI.Foundry` (+ `Azure.AI.Projects`, `Azure.AI.Agents.Persistent`) | Azure AI Foundry / persistent agents. |
+| `Microsoft.SemanticKernel.Connectors.OpenAI` / `.AzureOpenAI` | `Azure.AI.OpenAI` / `OpenAI` surfaced via `IChatClient` (`.AsIChatClient()`) | Provider SDKs consumed through MEAI. |
+| SK orchestration (`Microsoft.SemanticKernel.Agents.Orchestration`, `.Runtime.InProcess`) | `Microsoft.Agents.AI.Workflows` | Graph workflows + orchestration builders. |
+| (declarative / YAML) | `Microsoft.Agents.AI.Declarative`, `Microsoft.Agents.AI.Workflows.Declarative` | **Preview.** |
+| hosting / DI | `Microsoft.Agents.AI.Hosting` (+ `...Hosting.A2A`, `...Hosting.A2A.AspNetCore`) | `AddAIAgent`. |
+
+**Install (typical):** `dotnet add package Microsoft.Agents.AI`. Provider packages currently ship `--prerelease` variants alongside the stable 1.x core — **pin explicit versions**. Packages target **.NET 8.0 / .NET Standard 2.0 / .NET Framework 4.7.2+** (so .NET 10 is fine). MAF moved from the MEAI 9.x preview to the **stable `Microsoft.Extensions.AI` 10.4.1**.
+
+First-party providers at GA (exactly seven, per the 1.0 blog): **Microsoft Foundry, Azure OpenAI, OpenAI, Anthropic Claude, Amazon Bedrock, Google Gemini, and Ollama.**
+
+### 3. Core concept mapping
+
+| Semantic Kernel | Agent Framework | Notes |
+|---|---|---|
+| `Kernel` | *(gone)* | No kernel required; agent is built directly from a chat client. |
+| `ChatCompletionAgent`, `AzureAIAgent`, `OpenAIAssistantAgent` | `ChatClientAgent` / base `AIAgent` | One agent type over any `IChatClient`. |
+| `[KernelFunction]` + `KernelPlugin` + `Kernel.Plugins.Add` | `AIFunctionFactory.Create(method)` passed to `tools:` | Attribute not required; `[Description]` optional. |
+| `AgentThread` / `ChatHistory` | **`AgentSession`** (renamed from `AgentThread`) | `await agent.CreateSessionAsync()`. |
+| `AgentGroupChat` / SK orchestration | Workflows + orchestration builders | `AgentWorkflowBuilder`, `WorkflowBuilder`. |
+| `KernelArguments` + `PromptExecutionSettings` | `ChatOptions` (+ `ChatClientAgentRunOptions`) | `MaxTokens` → `MaxOutputTokens`. |
+| Function invocation filters / `IFunctionInvocationFilter` | Agent middleware / function middleware | `.AsBuilder().Use(...)`, `FunctionInvocationContext`. |
+| OpenTelemetry via SK | `.UseOpenTelemetry()` in the `IChatClient` pipeline | GenAI semantic conventions emitted automatically. |
+| DI: `AddKernel()` + keyed `Agent` | `AddAIAgent(...)` / `AddKeyedSingleton<AIAgent>` | From `Microsoft.Agents.AI.Hosting`. |
+| `agent.InvokeAsync` / `InvokeStreamingAsync` | `agent.RunAsync` / `RunStreamingAsync` | Returns `AgentRunResponse` / `IAsyncEnumerable<AgentRunResponseUpdate>`. |
+| Memory / vector connectors | `AIContextProvider` + Mem0 / Redis / Neo4j / Foundry memory | SK vector stores can be reused via adapter (see §4). |
+| MCP | `ModelContextProtocol` SDK; `McpClient.ListToolsAsync()` → tools; `McpServerTool` to expose | First-class. |
+| Human-in-the-loop / checkpointing | Built into Workflows + Durable extension | Durable hosting is **preview**. |
+
+**Invocation return types (authoritative, from the API reference):** `RunAsync(...)` returns `Task<AgentRunResponse>` — text in `.Text` / `.ToString()`, all messages (tool calls, function results, reasoning, final) in `.Messages`. `RunStreamingAsync(...)` returns `IAsyncEnumerable<AgentRunResponseUpdate>`. Conceptual docs sometimes write `AgentResponse` / `AgentResponseUpdate` in prose; the real type names are **`AgentRunResponse` / `AgentRunResponseUpdate`**.
+
+**Session serialization:** `JsonElement s = await agent.SerializeSessionAsync(session);` and `AgentSession restored = await agent.DeserializeSessionAsync(s);` — both on the **agent** (renamed from the old thread-based `thread.SerializeAsync()` / `agent.DeserializeThreadAsync()`). You **must use the same agent instance** for serialize/deserialize, because the agent attaches behaviors to the session.
+
+### 4. Interop / incremental migration
+- **Existing `[KernelFunction]` plugins transfer with zero changes** — MAF consumes the same methods as tools. To register in MAF, drop the plugin/kernel wrapper and pass the method to `AIFunctionFactory.Create(...)`.
+- **SK and MAF packages install together and coexist** in the same project; migrate file-by-file. A common intermediate `.csproj` keeps `Microsoft.SemanticKernel` for plugins/kernel config while adding `Microsoft.Agents.AI.OpenAI` / `Microsoft.Agents.AI.Workflows`.
+- **SK `KernelFunction` instances** (including prompt functions and vector-store `create_search_function` results) can be adapted to MAF tools. Python exposes a documented `.as_agent_framework_tool(kernel=...)` (requires `semantic-kernel` ≥ 1.38); in .NET, wrap the underlying method via `AIFunctionFactory.Create`. This lets you keep SK vector-store/RAG infrastructure while running MAF agents.
+- **Architectural layering:** `Microsoft.Extensions.AI (IChatClient)` → `Semantic Kernel (plugins/memory/filters)` → `Microsoft Agent Framework (agents + workflows)` → provider SDKs (Azure OpenAI / OpenAI / Anthropic / Ollama / …). SK becomes a foundation layer you can keep calling through the shared `IChatClient`.
+
+### 5. Before/after C# code
+
+**(a) Simple chat agent**
+```csharp
+// SK (before)
+Kernel kernel = Kernel.CreateBuilder()
+    .AddAzureOpenAIChatCompletion(deployment, endpoint, new DefaultAzureCredential())
+    .Build();
+ChatCompletionAgent agent = new() { Instructions = "You are helpful.", Kernel = kernel };
+
+// MAF (after)
+using Azure.AI.OpenAI;
+using Azure.Identity;
+using Microsoft.Agents.AI;
+
+AIAgent agent = new AzureOpenAIClient(new Uri(endpoint), new DefaultAzureCredential())
+    .GetChatClient(deployment)
+    .AsAIAgent(instructions: "You are helpful.", name: "Helper");
+
+Console.WriteLine(await agent.RunAsync("What is the largest city in France?"));
+```
+
+**(b) Agent with tools**
+```csharp
+// SK
+public class WeatherPlugin {
+    [KernelFunction, Description("Gets weather")]
+    public string GetWeather([Description("City")] string city) => $"{city}: sunny";
+}
+kernel.Plugins.AddFromType<WeatherPlugin>();
+
+// MAF
+using System.ComponentModel;
+using Microsoft.Extensions.AI;
+
+[Description("Gets weather")]
+static string GetWeather([Description("City")] string city) => $"{city}: sunny";
+
+AIAgent agent = chatClient.AsAIAgent(
+    instructions: "You help with weather.",
+    tools: [AIFunctionFactory.Create(GetWeather)]);
+```
+
+**(c) Providers (Azure OpenAI vs OpenAI vs Azure AI Foundry persistent agents)**
+```csharp
+// OpenAI
+AIAgent a = new OpenAIClient(apiKey).GetChatClient("gpt-4o-mini").AsAIAgent(instructions: "...");
+
+// Azure OpenAI + managed identity
+AIAgent b = new AzureOpenAIClient(new Uri(endpoint), new DefaultAzureCredential())
+    .GetChatClient(deployment).AsAIAgent(instructions: "...");
+
+// Azure AI Foundry (named, versioned, server-side persistent agent)
+AIProjectClient proj = new(new Uri(foundryEndpoint), new DefaultAzureCredential());
+AIAgent c = await proj.CreateAIAgentAsync(name: "FoundryAgent", model: deployment, instructions: "...");
+// retrieve existing: await proj.GetAIAgentAsync(agentId)  /  proj.AsAIAgent(agentRecord)
+// lower-level control: proj.GetPersistentAgentsClient()  (Azure.AI.Agents.Persistent)
+```
+> `RunAsync()`, `RunStreamingAsync()`, tools, and sessions behave identically whether the agent is local or Foundry-hosted; only the client construction differs.
+
+**(d) Sessions / multi-turn state**
+```csharp
+AgentSession session = await agent.CreateSessionAsync();
+Console.WriteLine(await agent.RunAsync("Hi, I'm Alex.", session));
+Console.WriteLine(await agent.RunAsync("What's my name?", session)); // remembers "Alex"
+
+// persist across restarts (same agent instance required to deserialize)
+JsonElement saved = await agent.SerializeSessionAsync(session);
+AgentSession resumed = await agent.DeserializeSessionAsync(saved);
+```
+
+**(e) Streaming**
+```csharp
+await foreach (AgentRunResponseUpdate update in agent.RunStreamingAsync("Tell a joke", session))
+    Console.Write(update); // update is ToString()-friendly
+```
+
+**(f) Structured output**
+```csharp
+using Microsoft.Extensions.AI;
+
+JsonElement schema = AIJsonUtilities.CreateJsonSchema(typeof(PersonInfo));
+ChatOptions opts = new() {
+    ResponseFormat = ChatResponseFormat.ForJsonSchema(schema, "PersonInfo", "A person") };
+AIAgent agent = chatClient.CreateAIAgent(new ChatClientAgentOptions { ChatOptions = opts });
+// or the generic helper: ChatResponseFormat.ForJsonSchema<PersonInfo>()
+```
+> **Known bug (agent-framework issue #2874):** `ResponseFormat = ForJsonSchema<T[]>` for arrays/lists returns HTTP 400 (`schema must be type: "object"`). The typed `RunAsync<T>()` path handles lists correctly. **Workaround:** wrap the array in an object type (e.g. `record MovieList(Movie[] Movies)`).
+
+**(g) Multi-agent orchestration (Workflows)**
+```csharp
+using Microsoft.Agents.AI.Workflows;
+
+// Sequential (pipeline)
+Workflow seq = AgentWorkflowBuilder.BuildSequential(writer, reviewer);
+
+// Concurrent (fan-out / fan-in)
+Workflow conc = AgentWorkflowBuilder.BuildConcurrent(physicist, chemist);
+
+// Handoff (dynamic routing) — replaces AgentGroupChat + custom selection
+Workflow handoff = AgentWorkflowBuilder.CreateHandoffBuilderWith(triage)
+    .WithHandoffs(triage, [travel, vision, general])
+    .WithHandoff(travel, triage)
+    .WithHandoff(vision, triage)
+    .WithHandoff(general, triage)
+    .Build();
+
+await using StreamingRun run = await InProcessExecution.RunStreamingAsync(seq, "input");
+await run.TrySendMessageAsync(new TurnToken(emitEvents: true));
+```
+Per the GA blog, **sequential, concurrent, handoff, group chat, and Magentic-One are all stable in .NET**, and "all patterns support streaming, checkpointing, human-in-the-loop approvals, and pause/resume." (One older Medium post wrongly claims Magentic is C#-unsupported — disregard; official docs and the orchestration-1.0 announcement confirm .NET support.) You can also compose agents as tools: `agentB.AsAIFunction()` passed into agent A's `tools:`. For custom graph topologies, drop to the raw `WorkflowBuilder` (executors + edges + superstep BSP execution model).
+
+**(h) ASP.NET Core hosting + DI**
+```csharp
+// Program.cs
+IChatClient chatClient = new AzureOpenAIClient(new Uri(endpoint), new DefaultAzureCredential())
+    .GetChatClient(deployment).AsIChatClient();
+builder.Services.AddSingleton(chatClient);
+
+// Register as keyed hosted agent (Microsoft.Agents.AI.Hosting)
+builder.AddAIAgent("writer", instructions: "You write short stories (<= 300 words).");
+// equivalent manual form:
+// builder.Services.AddKeyedSingleton<AIAgent>("weather",
+//     (sp,_) => chatClient.AsAIAgent(instructions: "...", name: "weather"));
+
+var app = builder.Build();
+// Optionally expose over the A2A protocol:
+// builder.Services.AddA2AServer(); app.MapA2AServer();
+app.Run();
+```
+`AddAIAgent` registers the agent as a **keyed service** (first-class like a `DbContext`/`HttpClient`). Hosting libraries act as protocol adapters (A2A, OpenAI-compatible, AG-UI), keeping your agent implementation protocol-agnostic.
+
+### 6. Azure-specific concerns
+- **Auth:** `DefaultAzureCredential` for dev; **in production prefer `ManagedIdentityCredential`** — the docs explicitly warn `DefaultAzureCredential` "requires careful consideration in production … to avoid latency issues, unintended credential probing, and potential security risks from fallback mechanisms."
+- **Azure AI Foundry:** `AIProjectClient.CreateAIAgentAsync(...)` creates a named, versioned, server-side persistent agent (definitions immutable after creation; `Agents.DeleteAgentAsync(name)` to remove). Retrieve with `GetAIAgentAsync` / `AsAIAgent(agentRecord)`. Lower-level control via `AIProjectClient.GetPersistentAgentsClient()` from `Azure.AI.Agents.Persistent`.
+- **Hosted MCP:** Foundry agents can attach a hosted `MCPToolDefinition(serverLabel, serverUrl)` with an allow-list and approval workflow.
+- **Local MCP:** `await using var mcpClient = await McpClient.CreateAsync(new StdioClientTransport(...));` → `var tools = await mcpClient.ListToolsAsync();` → pass into `AsAIAgent(tools: [...])`. Use `await using` (async disposal) or you leak the server process/socket in long-running services.
+- **Deployment:** package as ASP.NET Core / container → **Azure Container Apps**; or use the **Durable extension** for **Azure Functions** (persist sessions, checkpoint orchestration/workflow progress, HITL, scale-to-zero on Flex Consumption). Durable also supports bring-your-own-compute/self-hosted workers (`ConfigureDurableWorkflows`). The repo ships `dotnet/samples/04-hosting/DurableAgents/AzureFunctions` covering single-agent, chaining, concurrency, conditionals, HITL, and reliable streaming.
+- **Observability (Azure Monitor / App Insights):**
+  ```csharp
+  builder.Services.AddOpenTelemetry()
+      .UseAzureMonitor()  // reads APPLICATIONINSIGHTS_CONNECTION_STRING
+      .WithTracing(t => t
+          .AddSource("Microsoft.Extensions.AI*").AddSource("OpenAI*")
+          .AddSource("Experimental.OpenAI*").AddSource("Azure.AI.OpenAI*"))
+      .WithMetrics(m => m
+          .AddMeter("Microsoft.Extensions.AI*").AddMeter("OpenAI*"));
+  ```
+  Emits GenAI semantic conventions: `gen_ai.agent.name` / `gen_ai.agent.id` per span, `gen_ai.usage.input_tokens` / `output_tokens`, and `execute_tool` spans. App Insights has an **Agents (Preview)** view. Microsoft also ships an `opentelemetry-distro-dotnet` distro with `UseMicrosoftOpenTelemetry(o => { o.Exporters = ExportTarget.AzureMonitor; ... })` that auto-captures Agent Framework activity sources. Full prompt capture requires an explicit sensitive-data (`EnableSensitiveData`) flag.
+
+### 7. Known gaps, breaking changes, and not-yet-supported
+- **SK Process Framework is discontinued.** Microsoft (semantic-kernel Discussion #12270): *"We are not moving forward with the development of SK's Process Framework … please instead look at Microsoft Agent Framework Workflows … Orchestration patterns (group chat, magentic, handoff, etc.) are built on top of workflows APIs."* No automatic converter — re-model `KernelProcess` steps/edges as `WorkflowBuilder` executors/edges.
+- **Prompt template formats not ported.** SK's **Handlebars / Liquid / YAML** prompt templates and "agent-from-YAML-template" have no direct MAF equivalent (open discussion #1090). **Workaround:** render templates yourself (or keep SK for template rendering) and feed the resulting string as `instructions`. SK **planners** (Handlebars/Stepwise) are deprecated — rely on modern models' native tool-calling instead.
+- **API rename churn (breaking):** `AgentThread` → `AgentSession`, `GetNewThread()` → `CreateSessionAsync()`, `RunAsync` param `thread` → `session`, and serialize/deserialize moved onto the agent. If you used **named arguments** (`RunAsync(..., thread: t)`), that is now a **compile error**. Microsoft's `/dotnet/api/...` reference pages lag and still show old names in places — trust the conceptual docs + migration guide.
+- **Structured-output arrays bug** — see §5(f).
+- **Preview-only (functional, APIs may evolve):** Declarative (YAML) tooling in .NET, Durable/hosting extensions, DevUI, Foundry hosted-agent integration, AG-UI adapters, Skills, and the GitHub Copilot / Claude Code harness.
+- **`.GetChatClient()` vs `IChatClient` gotcha:** `OpenAIClient` / `AzureOpenAIClient`.`GetChatClient()` returns the **OpenAI SDK `ChatClient`**, not MEAI `IChatClient`. For the generic `CreateAIAgent` / `AsAIAgent` on `IChatClient`, insert **`.AsIChatClient()`**; the provider packages (`Microsoft.Agents.AI.OpenAI`) also supply overloads that accept the native client directly. A mismatch produces compile error **CS1929** (notably under the .NET 10 SDK).
+
+### 8. Step-by-step migration sequence (ordered, for an AI coding agent)
+1. **Inventory.** Grep for: `Microsoft.SemanticKernel`, `Kernel`, `ChatCompletionAgent`, `AzureAIAgent`, `OpenAIAssistantAgent`, `[KernelFunction]`, `AgentGroupChat`, `KernelArguments`, `PromptExecutionSettings`, `IFunctionInvocationFilter`, `KernelProcess`, `ChatHistory`, `AgentThread`. Classify each file by pattern. **Verify:** produce a mapping table; nothing unclassified.
+2. **Add packages side-by-side.** Add `Microsoft.Agents.AI`, `Microsoft.Extensions.AI`, and provider packages; **keep SK installed**. **Verify:** solution still builds.
+3. **Migrate provider/client setup.** Replace kernel-builder chat-completion registration with a provider client → `.AsAIAgent(...)` (insert `.AsIChatClient()` where needed). **Verify:** one agent returns a response.
+4. **Migrate tools.** Remove `[KernelFunction]` + plugin/kernel registration; pass methods via `AIFunctionFactory.Create(...)` in `tools:`; keep `[Description]`. **Verify:** a prompt that requires a tool triggers the tool call.
+5. **Migrate state.** Replace `ChatHistory`/`AgentThread` with `AgentSession` via `CreateSessionAsync()`; update `RunAsync`/`RunStreamingAsync` to pass `session`; replace serialization with `SerializeSessionAsync`/`DeserializeSessionAsync`. **Verify:** multi-turn memory + serialize→deserialize round-trip.
+6. **Migrate options.** `PromptExecutionSettings`/`KernelArguments` → `ChatOptions`/`ChatClientAgentRunOptions`; `MaxTokens` → `MaxOutputTokens`. **Verify:** token/temperature limits take effect.
+7. **Migrate filters → middleware.** Convert `IFunctionInvocationFilter` to agent/function middleware (`.AsBuilder().Use(...)`, `FunctionInvocationContext`). **Verify:** middleware fires around runs and function calls.
+8. **Migrate orchestration.** Replace `AgentGroupChat`/SK orchestration with `AgentWorkflowBuilder` (sequential/concurrent/handoff/group chat/magentic) or raw `WorkflowBuilder`. **Verify:** ordering/fan-in matches the SK version on the same inputs.
+9. **Migrate DI/hosting.** Replace `AddKernel()` + keyed `Agent` with `AddAIAgent(...)` / `AddKeyedSingleton<AIAgent>`; wire OpenTelemetry. **Verify:** DI resolves the agent; telemetry flows.
+10. **Handle gaps.** Re-model Process Framework as Workflows; externalize prompt templates (render → `instructions`). **Verify:** each gap has a working workaround or a documented deferral.
+11. **Remove SK** packages/usings from fully migrated files once parity is verified. Keep SK **only** where a gap remains. **Verify:** build clean; no stale `Microsoft.SemanticKernel` usings in migrated files.
+12. **Full regression** (build + entire test suite) before merge.
+
+### 9. Testing strategy for behavioral parity
+- **Golden-transcript tests:** capture SK inputs/outputs before migration; replay against MAF. For nondeterministic text, assert on **tool-call sequences**, **structured-output schema conformance**, and **semantic similarity** (Azure AI Evaluation SDK `SimilarityEvaluator`, target mean **≥ 3.5 / 5**) rather than exact strings.
+- **Tool-invocation assertions:** verify the same tools are called with the same arguments (middleware/telemetry spans make this observable).
+- **Session/state tests:** multi-turn memory retention; serialize → deserialize round-trip on the **same agent instance**.
+- **Structured-output tests:** validate JSON against schema; **specifically test array/list outputs** (known bug in §5f).
+- **Orchestration tests:** deterministic patterns (sequential/concurrent) assert ordering and fan-in aggregation; run SK vs MAF side by side with identical inputs.
+- **Observability checks:** confirm `gen_ai.*` spans and token metrics reach App Insights and that per-agent segmentation works.
+
+### 10. F# considerations (relevant if the codebase is F#/.NET 10)
+MAF is a standard .NET library callable from F#; NuGet even documents F# Interactive `#r "nuget: Microsoft.Agents.AI, ..."` usage. Caveats:
+- **Tools via `AIFunctionFactory.Create`** generate JSON Schema from parameter types. Per practitioner guidance: *"Simple types (string, int, double, bool) and records with simple properties work well. Complex nested types can work but produce more elaborate schemas."* Prefer explicit `name` and `[<Description>]` for reliability.
+- **Attributes:** use `[<Description("...")>]` on parameters. `[KernelFunction]` is **not needed at all** in MAF, which actually simplifies F# tool authoring (no attribute plumbing).
+- **Async interop:** MAF returns `Task` / `IAsyncEnumerable`. Bridge with `Async.AwaitTask` / the `task { }` computation expression, and handle streaming via `IAsyncEnumerable`/`TaskSeq`.
+- **Records / discriminated unions:** F# records map cleanly to structured-output schemas; **DUs have no clean JSON-schema representation** — avoid them at the tool/structured-output boundary or supply a custom `JsonConverter`.
+- No F#-specific MAF package exists; consume the C# API directly. **Validate schema generation** for any record/collection used as a tool parameter or structured-output type before relying on it.
+
+## Recommendations
+1. **Start new agent code on MAF now; migrate existing SK agents in stages.** Because SK v1.x is supported ≥1 year post-GA (April 2026 baseline), avoid a big-bang. Trigger full migration of a module when it needs MAF-only features (MCP, handoff/magentic orchestration, checkpointing/durability, HITL).
+2. **Follow the ordered sequence** in §8 (packages → single agent → tools → state → options → filters/middleware → orchestration → DI/hosting → gaps → remove SK), and **verify build + targeted tests at each step** before proceeding.
+3. **Keep SK deliberately** where MAF has gaps: Process Framework workloads, prompt-template-heavy prompts, and mature vector-store/RAG pipelines — bridge via the shared `IChatClient` and `AIFunctionFactory` tool interop rather than rewriting them.
+4. **Pin versions** (`Microsoft.Agents.AI` 1.15.0, `Microsoft.Extensions.AI` 10.4.1, and known-good provider prereleases) and treat any `*.Declarative` / hosting / durable / DevUI preview package as changeable.
+5. **Always emit the new API names** (`AgentSession`, `CreateSessionAsync`, `session`, `SerializeSessionAsync`/`DeserializeSessionAsync`) even though some Microsoft `/dotnet/api` reference pages still show the old `AgentThread`/`GetNewThread` names.
+6. **Benchmarks/thresholds that change the plan:** if similarity parity < **3.5/5** or tool-call sequences diverge, **stop** and fix prompt/tool wiring before removing SK. If a module depends on Process Framework or prompt templates with no viable workaround, **defer** that module and keep it on SK until a workaround exists.
+
+## Caveats
+- MAF is young: smaller community and fewer answered edge-case questions than SK — factor in for tricky scenarios.
+- Some code in blogs and in Microsoft's **auto-generated `/dotnet/api` reference pages predates the `AgentSession` rename**; cross-check against the conceptual docs and the SK→MAF migration guide, not the API-reference pages.
+- Preview features (durable hosting, declarative YAML in .NET, DevUI, Skills, harness) may change before their own GA.
+- The exact release number where the `thread` → `session` rename landed is **not pinned to a single changelog line**; evidence points to the 1.0 GA window (April 2026) and it is confirmed present through 1.13–1.15.
+- Provider packages ship prerelease variants alongside the stable core; version skew can cause CS1929 with `.GetChatClient()` vs `IChatClient` (fix with `.AsIChatClient()`).
+- "Magentic not supported in C#" claims found in some community posts are **outdated** — Magentic-One is stable in .NET as of 1.0.
+
+## Sources
+- Agent Framework Overview (C#): https://learn.microsoft.com/en-us/agent-framework/overview/?pivots=programming-language-csharp
+- Semantic Kernel → Agent Framework Migration Guide: https://learn.microsoft.com/en-us/agent-framework/migration-guide/from-semantic-kernel/
+- MAF 1.0 GA announcement: https://devblogs.microsoft.com/agent-framework/microsoft-agent-framework-version-1-0/
+- Release Candidate announcement: https://devblogs.microsoft.com/foundry/microsoft-agent-framework-reaches-release-candidate/
+- SK & MAF support policy: https://devblogs.microsoft.com/agent-framework/semantic-kernel-and-microsoft-agent-framework/
+- .NET Blog — Building Blocks for AI Part 3 (sessions, serialize, `AsAIAgent`): https://devblogs.microsoft.com/dotnet/microsoft-agent-framework-building-blocks-for-ai-part-3/
+- `AgentSession` API reference: https://learn.microsoft.com/en-us/dotnet/api/microsoft.agents.ai.agentsession
+- Session conceptual doc: https://learn.microsoft.com/en-us/agent-framework/agents/conversations/session
+- Workflows overview / orchestrations / Magentic: https://learn.microsoft.com/en-us/agent-framework/workflows/ · /orchestrations/ · /orchestrations/magentic
+- Orchestration patterns reach 1.0: https://devblogs.microsoft.com/agent-framework/agent-frameworks-orchestration-patterns-reach-1-0/
+- Hosting (ASP.NET Core DI, A2A): https://learn.microsoft.com/en-us/agent-framework/get-started/hosting · https://learn.microsoft.com/en-us/agent-framework/hosting/agent-to-agent
+- Local MCP tools / Hosted MCP tools: https://learn.microsoft.com/en-us/agent-framework/agents/tools/local-mcp-tools · /hosted-mcp-tools
+- Structured output: https://learn.microsoft.com/en-us/agent-framework/agents/structured-outputs · Array bug: https://github.com/microsoft/agent-framework/issues/2874
+- Durable extension (Azure Functions): https://learn.microsoft.com/en-us/agent-framework/integrations/durable-extension · Samples: https://github.com/microsoft/agent-framework/tree/main/dotnet/samples/04-hosting/DurableAgents/AzureFunctions
+- Observability (App Service tutorial): https://learn.microsoft.com/en-us/azure/app-service/tutorial-ai-agent-monitoring-dotnet · OpenTelemetry distro: https://github.com/microsoft/opentelemetry-distro-dotnet
+- Azure AI Foundry (persistent agents): https://learn.microsoft.com/en-us/agent-framework/user-guide/agents/agent-types/azure-ai-foundry-agent · https://learn.microsoft.com/en-us/dotnet/api/overview/azure/ai.projects-readme
+- Process Framework discontinued: https://github.com/microsoft/semantic-kernel/discussions/12270
+- Prompt template gap discussion: https://github.com/microsoft/agent-framework/discussions/1090
+- Multi-turn / thread(session) migration (SK support page): https://learn.microsoft.com/en-us/semantic-kernel/support/migration/agent-framework-rc-migration-guide
+- NuGet (Microsoft.Agents.AI 1.15.0): https://www.nuget.org/packages/Microsoft.Agents.AI/
+- GitHub repo: https://github.com/microsoft/agent-framework

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this is
 
-A semantic (LLM-driven) chat API over The Movie DB. Users ask natural-language questions ("what action movies in the 90s did the main actor also star in a comedy with Meg Ryan in the 80s?"); Semantic Kernel plans and auto-invokes kernel functions against TMDb/OMDb/Wikipedia to answer. See `Readme.md` for the product framing and example queries.
+A semantic (LLM-driven) chat API over The Movie DB. Users ask natural-language questions ("what action movies in the 90s did the main actor also star in a comedy with Meg Ryan in the 80s?"); **Microsoft Agent Framework** plans and auto-invokes tools against TMDb/OMDb/Wikipedia to answer. See `Readme.md` for the product framing and example queries.
+
+Migrated off Semantic Kernel in July 2026 — see `AGENT_FRAMEWORK_MIGRATION.md` for the reference guide the migration followed, and "Agent Framework wiring" below for what the result looks like. There is no Semantic Kernel left in the project.
 
 Single .NET 10 isolated-worker Azure Functions project: `src/MovieTracker.Backend`. Infrastructure is Bicep in `infrastructure/`. There is no test project.
 
@@ -49,8 +51,10 @@ CI does not build or test — `.github/workflows/pr-function.yml` deploys an eph
 
 Two HTTP functions, both in `Functions/Function.cs`:
 
-- `Chat-Start` (`GET /api/chat/start`) — creates a `ChatHistory` seeded with the **system prompt defined inline in this method**, persists it to Cosmos, returns a short `chatId`. That prompt is the contract for the whole app: it forces the model to reply with a JSON object of `SystemMessage` + `MovieList[{MovieId, MovieName}]`, and to wrap trailer URLs in `[TRAILER]...[/TRAILER]` for the frontend to render inline. Changing response shape means changing this prompt *and* the `MovieListResponse` type used as the structured-output schema.
-- `Chat-Ask` (`POST /api/chat/{chatId}/ask`) — loads the session, runs the planner, calls the LLM with `ToolCallBehavior.AutoInvokeKernelFunctions` and `ResponseFormat = typeof(MovieListResponse)` (SKEXP0010 structured outputs), then **hydrates** the returned `MovieId`s.
+- `Chat-Start` (`GET /api/chat/start`) — creates a `List<ChatMessage>` seeded with the **system prompt defined inline in this method**, persists it to Cosmos, returns a short `chatId`. That prompt is the contract for the whole app: it forces the model to reply with a JSON object of `SystemMessage` + `MovieList[{MovieId, MovieName}]`, and to wrap trailer URLs in `[TRAILER]...[/TRAILER]` for the frontend to render inline. Changing response shape means changing this prompt *and* the `MovieListResponse` type used as the structured-output schema.
+- `Chat-Ask` (`POST /api/chat/{chatId}/ask`) — loads the session, runs the planner, calls `agent.RunAsync(...)` with the `MovieListResponse` structured-output format, then **hydrates** the returned `MovieId`s.
+
+**Structured-output trap.** `MovieListResponseFormat` in `Function.cs` is built with `AIJsonUtilities.CreateJsonSchema` and `AIJsonSchemaTransformOptions { DisallowAdditionalProperties = true, RequireAllProperties = true }`, not with the obvious `ChatResponseFormat.ForJsonSchema(typeof(MovieListResponse), ...)`. The convenient overload emits a schema with no `required` array and no `additionalProperties: false`, which Azure OpenAI's strict structured outputs reject with HTTP 400 — Semantic Kernel's `ResponseFormat = typeof(T)` used to emit the strict dialect for you. The serializer options also pin `PropertyNamingPolicy = null`, because Microsoft.Extensions.AI defaults to camelCase and the system prompt and `ProcessMovieAsync` both depend on PascalCase `SystemMessage`/`MovieList`/`MovieId`.
 
 Hydration is the key two-layer design: the LLM only ever returns TMDb movie IDs; `ProcessMovieAsync` fans out over them, calls TMDbLib for full details plus the best YouTube trailer, and builds the `MovieViewModel` the frontend consumes. Results are cached per `movieId` in `IDistributedCache` (registered as `AddDistributedMemoryCache` — in-process, per-instance, no expiry set).
 
@@ -58,28 +62,45 @@ Note that `Chat-Ask` re-walks and re-hydrates the *entire* chat history on every
 
 Anything the model supplies — movie ids, release years, cast/genre/keyword id lists — is treated as untrusted input. It routinely invents non-numeric ids, so parsing goes through `TryGetTmdbId`/`ParseIdList` in `TheMovieDBKernelFunctions`, which hand the model a correctable error instead of throwing; `SafeProcessMovieAsync` isolates per-movie hydration so one bad entry cannot fail the whole response. A bare `int.Parse` on a model-supplied value is a bug waiting to happen.
 
-The named `"HttpClient"` in `Program.cs` is used **only** by the Kernel (Cosmos takes the unnamed default), and its resilience timeouts are widened well past the 30s default because reasoning models are slow. They stay inside the platform's ~230s hard limit on HTTP triggers.
+The named `"HttpClient"` in `Program.cs` is used **only** by the Azure OpenAI chat client (Cosmos takes the unnamed default), and its resilience timeouts are widened well past the 30s default because reasoning models are slow. They stay inside the platform's ~230s hard limit on HTTP triggers. It reaches the SDK through `AzureOpenAIClientOptions.Transport = new HttpClientPipelineTransport(httpClient)` — if that is dropped, the widened timeouts silently stop applying.
 
-### Semantic Kernel wiring
+### Agent Framework wiring
 
-`Program.cs` registers `Kernel` as **scoped**, backed by **Azure OpenAI in Microsoft Foundry** (`AddAzureOpenAIChatCompletion`) against the `gpt-5-4-mini` deployment in `infrastructure/ai-foundry.bicep`, and adds two plugins at build time:
+`Program.cs` registers two things as **scoped**:
+
+- `IChatClient` — `AzureOpenAIClient(...).GetChatClient(deployment).AsIChatClient()`, against **Azure OpenAI in Microsoft Foundry** (`gpt-5-4-mini`, see `infrastructure/ai-foundry.bicep`), wrapped in `.UseOpenTelemetry(..., EnableSensitiveData = true)`. `GetChatClient` returns the *OpenAI SDK* `ChatClient`, so `AsIChatClient()` is mandatory — omitting it is compile error CS1929.
+- `AIAgent` — `chatClient.AsAIAgent(...)` with the full tool list. `ChatClientAgent` decorates the chat client with automatic function invocation by default, which is what `ToolCallBehavior.AutoInvokeKernelFunctions` used to do.
+
+**The split matters.** `ChatPlanner` and `TrailerAgent` take the bare `IChatClient`, *not* the agent, because their prompts (entity detection, funny facts, trailer-title extraction) must run without the agent's tool set and JSON response format. Under Semantic Kernel they resolved `IChatCompletionService` off the kernel for the same reason.
+
+There is no attribute-driven tool discovery any more. `Plugins.AddFromType<T>()` is replaced by explicit `CreateTools()` methods returning `IEnumerable<AITool>` built with `AIFunctionFactory.Create`, and `Program.cs` unions the three sources. **Adding a `[Description]`-annotated method without adding it to the matching `CreateTools()` leaves it invisible to the model** — this is the single easiest thing to get wrong.
 
 - `Prompts/TheMovieDBKernelFunctions.cs` — the main TMDb surface (genres, person search, movie search, discover with filters, movie details, trailers/videos).
-- `Prompts/DateTimeKernelFunctions.cs` — relative-date helpers so the model can resolve "in the last 10 years" into ISO date ranges rather than hallucinating them.
+- `Prompts/DateTimeKernelFunctions.cs` — relative-date helpers so the model can resolve "in the last 10 years" into ISO date ranges rather than hallucinating them. Static methods.
+- `Prompts/ChatPlanner.cs` — the façade over the `Agents/` classes (ratings, trailers, Wikipedia-backed "funny facts" and context). Now a normal scoped DI service; it used to be constructed by hand in `Chat-Ask` and bolted onto the kernel per request.
 
-`Prompts/ChatPlanner.cs` is added as a plugin **per request** inside `Chat-Ask` (`kernel.Plugins.Add(KernelPluginFactory.CreateFromObject(chatPlanner))`). It is the kernel-facing façade over the `Agents/` classes — ratings, trailers, Wikipedia-backed "funny facts" and context.
+The class names still end in `KernelFunctions` for continuity with the file history; there are no kernels involved.
 
-`Agents/` are plain DI services, not plugins (`WikipediaSearchAgent` carries `[KernelFunction]` attributes but is never registered as a plugin — it's reached through `ChatPlanner`):
+`Agents/` are plain DI services, never exposed to the model directly (`WikipediaSearchAgent` keeps `[Description]` attributes but is reached only through `ChatPlanner`):
 
 - `OpenMovieDbAgent` — OMDb ratings. IMDb rating is intentionally the primary/default rating everywhere; Rotten Tomatoes and Metacritic are secondary context only.
 - `WikipediaSearchAgent` — Wikipedia REST summary + Wikidata SPARQL, with a confidence score gating whether the enriched path or the basic path is used.
 - `TrailerAgent` — keyword-gated (`CanHandle`) flow: extract title via LLM → TMDb search → best official YouTube trailer → `[TRAILER]url[/TRAILER]`.
 
-**To add a new external data source:** add the class under `Agents/`, register it scoped in `Program.cs`, thread it through `ChatPlanner`'s constructor, and add a `[KernelFunction]` wrapper there. `ChatPlanner` is constructed by hand in `Chat-Ask`, so its constructor args must also be added to the `Function` primary constructor.
+**To add a new external data source:** add the class under `Agents/`, register it scoped in `Program.cs`, thread it through `ChatPlanner`'s constructor, add a `[Description]`-annotated wrapper method there, **and add that method to `ChatPlanner.CreateTools()`** — the last step is what actually exposes it to the model.
 
 ### Persistence
 
-`ChatSessionRepository.cs` — Cosmos DB, database `database`, container `chat-sessions`, hardcoded. Document id doubles as the partition key; ids come from `GenId()` (base64 of 5 random bytes, regenerated until URL-safe-clean). The Semantic Kernel `ChatHistory` object is serialized straight into the document via `CosmosSystemTextJsonSerializer`.
+`ChatSessionRepository.cs` — Cosmos DB, database `database`, container `chat-sessions`, hardcoded. Document id doubles as the partition key; ids come from `GenId()` (base64 of 5 random bytes, regenerated until URL-safe-clean). The conversation is a `List<Microsoft.Extensions.AI.ChatMessage>` serialized straight into the document via `CosmosSystemTextJsonSerializer`.
+
+Two constraints on that serializer, both load-bearing:
+
+- Its options come from `AIJsonUtilities.DefaultOptions`, because `ChatMessage.Contents` is a polymorphic `IList<AIContent>`. Plain reflection-based options write the `$type` discriminators but cannot read `FunctionCallContent`/`FunctionResultContent` back, so a session with tool calls fails to load.
+- `PropertyNamingPolicy` is pinned to `null`. `AIJsonUtilities.DefaultOptions` is camelCase, which would rename `PartitionKey` and break every existing document.
+
+The `ChatHistory` *property name* is kept, but its serialized element shape is not the old Semantic Kernel one, so **chat sessions created before the migration cannot be loaded**. New `/api/chat/start` sessions are unaffected; the external HTTP contract did not change.
+
+`Chat-Ask` runs the agent with `session: null`, which is stateless — the whole conversation is passed in on each call and `result.Messages` is appended back. That is deliberately the same shape the Semantic Kernel version had with a `ChatHistory`, and it is what lets the response be rebuilt by re-walking the conversation. The intermediate function-call and function-result messages are persisted too: they carry no text (so the response-building loop skips them), but a tool call without its result is an invalid conversation on the next turn.
 
 ### Configuration
 
@@ -104,7 +125,7 @@ The account lives in **westus**, not the resource group's westus2, which offers 
 
 The Cognitive Services account was upgraded in place from `kind: 'OpenAI'` to `kind: 'AIServices'` with `allowProjectManagement: true` (`infrastructure/ai-foundry.bicep`). The resource name, custom subdomain, `openai.azure.com` endpoint, API keys and existing deployments all survive the upgrade, so no application code changed. It is reversible by setting `kind` back to `OpenAI` after deleting any projects and non-OpenAI deployments.
 
-**Trap:** on an `AIServices` account, `properties.endpoint` returns the generic `https://<name>.cognitiveservices.azure.com/` FQDN, but Semantic Kernel appends `/openai/deployments/<deployment>/chat/completions`, which is served only on `openai.azure.com`. `kv-secrets-openai.bicep` therefore builds the endpoint from `customSubDomainName` instead of reading `properties.endpoint` — reverting that silently breaks every `Chat-Ask` call on the next `main.bicep` deployment.
+**Trap:** on an `AIServices` account, `properties.endpoint` returns the generic `https://<name>.cognitiveservices.azure.com/` FQDN, but `AzureOpenAIClient` appends `/openai/deployments/<deployment>/chat/completions`, which is served only on `openai.azure.com`. `kv-secrets-openai.bicep` therefore builds the endpoint from `customSubDomainName` instead of reading `properties.endpoint` — reverting that silently breaks every `Chat-Ask` call on the next `main.bicep` deployment. (This survived the Agent Framework migration unchanged: the URL is built by the Azure SDK, not by the agent layer.)
 
 Do not set `disableLocalAuth: true` (as the Microsoft upgrade doc's sample does). The function app authenticates with an API key from Key Vault.
 
@@ -126,7 +147,11 @@ Measured head-to-head on this app's own system prompt and tool set (end-to-end, 
 
 The dominant cost was hidden reasoning tokens, not the per-token rate: `gpt-5-mini` spent **1344 of its 1587 completion tokens per turn on reasoning**. `gpt-5.4-mini` emits none at default effort.
 
-`AzureOpenAi:Reasoning-Effort` sets `OpenAIPromptExecutionSettings.ReasoningEffort`. Leave it `default` (or empty) to omit the parameter. Valid values are model-family-specific — `minimal` works on `gpt-5-mini`, `none` is **rejected** on `gpt-5.4-mini` through the API version Semantic Kernel uses, and non-reasoning models such as `grok-4-1-fast-non-reasoning` reject the parameter outright. A wrong value fails every `Chat-Ask` with HTTP 400.
+Those absolute latencies drift between sessions — the same unchanged code measured 29.8s in the morning and 33.3s the same evening. Treat the table as a *relative* comparison, and re-baseline in the same session before concluding anything has regressed.
+
+`AzureOpenAi:Reasoning-Effort` is applied in `Chat-Ask` through `ChatOptions.RawRepresentationFactory`, setting the OpenAI SDK's `ChatCompletionOptions.ReasoningEffortLevel` (gated behind `#pragma warning disable OPENAI001`). Leave it `default` (or empty) to omit the parameter. Valid values are model-family-specific — `minimal` works on `gpt-5-mini`, `none` is **rejected** on `gpt-5.4-mini` through the API version in use, and non-reasoning models such as `grok-4-1-fast-non-reasoning` reject the parameter outright. A wrong value fails every `Chat-Ask` with HTTP 400.
+
+It deliberately does **not** use `ChatOptions.Reasoning`: that takes a `ReasoningEffort` enum limited to `None`/`Low`/`Medium`/`High`/`ExtraHigh`, which cannot express `minimal`. Dropping to the provider options preserves the arbitrary-string passthrough this setting needs.
 
 `dynamicThrottlingEnabled` cannot be set on these deployments — the control plane rejects it for `DataZoneStandard`. Headroom comes from capacity instead. Anthropic models (`claude-haiku-4-5`) additionally require `ModelProviderData` (industry, organization name, country code) that the `az cognitiveservices` CLI does not expose, so deploying one needs the portal or a raw ARM call.
 
@@ -134,4 +159,4 @@ A missing `OpenMovieDb:Api-Key` fails at DI resolution of `OpenMovieDbAgent`, wh
 
 ### Observability
 
-OpenTelemetry traces export to Azure Monitor. Every function and repository method opens a span named `movie-tracker-func.*` via the injected `Tracer`; keep that convention when adding operations. SK sensitive-diagnostics is enabled in `Program.cs`, so prompts and completions appear in traces.
+OpenTelemetry traces export to Azure Monitor. Every function and repository method opens a span named `movie-tracker-func.*` via the injected `Tracer`; keep that convention when adding operations. Model spans come from `.UseOpenTelemetry(loggerFactory, serviceName, o => o.EnableSensitiveData = true)` on the `IChatClient`, which replaced the `Microsoft.SemanticKernel.Experimental.GenAI.EnableOTelDiagnosticsSensitive` AppContext switch — prompts and completions still appear in traces. The activity source is `serviceName` itself, so it is covered by the existing `AddSource(serviceName)`; `Microsoft.Extensions.AI*` and `Microsoft.Agents.AI*` are registered alongside it for the `execute_tool` spans.

--- a/src/MovieTracker.Backend/Agents/TrailerAgent.cs
+++ b/src/MovieTracker.Backend/Agents/TrailerAgent.cs
@@ -1,6 +1,5 @@
-﻿using Microsoft.Extensions.Configuration;
-using Microsoft.SemanticKernel;
-using Microsoft.SemanticKernel.ChatCompletion;
+﻿using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Configuration;
 using System.Text.Json;
 using TMDbLib.Client;
 
@@ -9,16 +8,21 @@ namespace MovieTracker.Backend.Agents
     public class TrailerAgent
     {
         private readonly string apiKey;
-        private readonly IChatCompletionService chatService;
+
+        // The bare IChatClient, deliberately not the AIAgent: this is a single-shot extraction prompt
+        // that must not inherit the agent's tool set or its JSON response format. Under Semantic
+        // Kernel this was kernel.GetRequiredService<IChatCompletionService>() called with no
+        // execution settings, which had the same effect.
+        private readonly IChatClient chatClient;
 
         private static readonly string[] TrailerKeywords = {
             "trailer", "preview", "teaser", "video", "watch", "play", "show", "promo", "attraction video"
         };
 
-        public TrailerAgent(IConfiguration configuration, Kernel kernel)
+        public TrailerAgent(IConfiguration configuration, IChatClient chatClient)
         {
             this.apiKey = configuration["TheMovieDb:Api-Key"] ?? throw new ArgumentNullException("Missing The Movie Db Api Key");
-            this.chatService = kernel.GetRequiredService<IChatCompletionService>();
+            this.chatClient = chatClient;
         }
 
         public bool CanHandle(string userQuery)
@@ -55,8 +59,8 @@ namespace MovieTracker.Backend.Agents
                 'trailer please' -> 'UNKNOWN'
                 ";
 
-            var result = await chatService.GetChatMessageContentAsync(prompt);
-            var movieTitle = result.Content?.Trim();
+            var result = await chatClient.GetResponseAsync(prompt);
+            var movieTitle = result.Text?.Trim();
 
             return movieTitle?.ToUpper() == "UNKNOWN" ? "" : movieTitle ?? "";
         }

--- a/src/MovieTracker.Backend/Agents/WikipediaSearchAgent.cs
+++ b/src/MovieTracker.Backend/Agents/WikipediaSearchAgent.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Extensions.Logging;
-using Microsoft.SemanticKernel;
 using System.ComponentModel;
 using System.Text.Json;
 
@@ -16,7 +15,9 @@ namespace MovieTracker.Backend.Agents
             this.logger = logger;
         }
 
-        [KernelFunction]
+        // Reached through ChatPlanner rather than exposed to the model directly - it was never
+        // registered as a plugin under Semantic Kernel either. The [Description] attributes are kept
+        // so it can be turned into a tool later without rediscovering the wording.
         [Description("Gets enhanced movie/actor information from Wikipedia and Wikidata")]
         [return: Description("Rich information including trivia, context, and detailed facts")]
         public async Task<WikipediaResult?> GetEnhancedInfo(

--- a/src/MovieTracker.Backend/ChatSessionRepository.cs
+++ b/src/MovieTracker.Backend/ChatSessionRepository.cs
@@ -1,6 +1,5 @@
-﻿using Microsoft.Azure.Cosmos;
+using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Logging;
-using Microsoft.SemanticKernel.ChatCompletion;
 using OpenTelemetry.Trace;
 using System;
 using System.Collections.Generic;
@@ -9,6 +8,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
+using ChatMessage = Microsoft.Extensions.AI.ChatMessage;
 
 namespace MovieTracker.Backend
 {
@@ -16,7 +16,13 @@ namespace MovieTracker.Backend
     {
         public string id { get; set; }
         public string PartitionKey { get; set; }
-        public ChatHistory ChatHistory { get; set; }
+
+        // Was a Semantic Kernel ChatHistory. The Agent Framework has no equivalent aggregate type -
+        // conversation state is either an opaque AgentSession or, as here, a plain message list that
+        // the caller owns. The property name is kept so the rest of the Cosmos document shape is
+        // unchanged, but the serialized form of the array elements is different, so chat sessions
+        // created before this migration cannot be loaded.
+        public List<ChatMessage> ChatHistory { get; set; }
         public string? FunnyFact { get; set; }
     }
 
@@ -37,7 +43,7 @@ namespace MovieTracker.Backend
             }
         }
 
-        public async Task<MoviceTrackerChatSession> NewChatSession(ChatHistory chatHistory)
+        public async Task<MoviceTrackerChatSession> NewChatSession(List<ChatMessage> chatHistory)
         {
             using var activity = tracer.StartActiveSpan("movie-tracker-func.chat-session-repository.new-chat-session");
             try
@@ -77,7 +83,7 @@ namespace MovieTracker.Backend
             }
         }
 
-        public async Task<MoviceTrackerChatSession> UpdateChatSession(string id, ChatHistory chatHistory)
+        public async Task<MoviceTrackerChatSession> UpdateChatSession(string id, List<ChatMessage> chatHistory)
         {
             using var activity = tracer.StartActiveSpan("movie-tracker-func.chat-session-repository.update-chat-session");
             try
@@ -95,7 +101,7 @@ namespace MovieTracker.Backend
             }
         }
 
-        public async Task<MoviceTrackerChatSession> UpdateChatSession(string id, ChatHistory chatHistory, string? funnyFact)
+        public async Task<MoviceTrackerChatSession> UpdateChatSession(string id, List<ChatMessage> chatHistory, string? funnyFact)
         {
             using var activity = tracer.StartActiveSpan("movie-tracker-func.chat-session-repository.update-chat-session-with-funny-fact");
             try

--- a/src/MovieTracker.Backend/CosmosSystemTextJsonSerializer.cs
+++ b/src/MovieTracker.Backend/CosmosSystemTextJsonSerializer.cs
@@ -1,9 +1,11 @@
 ﻿using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.AI;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 using System.Threading.Tasks;
 
 namespace MovieTracker.Backend
@@ -12,12 +14,26 @@ namespace MovieTracker.Backend
     {
         private JsonSerializerOptions _serializerOptions;
 
+        /// <summary>
+        /// Chat sessions store Microsoft.Extensions.AI ChatMessage objects, whose Contents property is
+        /// a polymorphic IList&lt;AIContent&gt;. Round-tripping those requires the type resolver from
+        /// AIJsonUtilities.DefaultOptions, which knows the $type discriminators for every AIContent
+        /// subclass; plain reflection-based options deserialize them back as the abstract base and
+        /// throw. It is combined with the default reflection resolver so the surrounding Cosmos
+        /// document POCO still serializes normally, and the naming policy is pinned to null (PascalCase)
+        /// so that document's existing property names - notably PartitionKey - do not change.
+        /// </summary>
+        private static JsonSerializerOptions CreateDefaultOptions() => new(AIJsonUtilities.DefaultOptions)
+        {
+            PropertyNamingPolicy = null,
+            TypeInfoResolver = JsonTypeInfoResolver.Combine(
+                AIJsonUtilities.DefaultOptions.TypeInfoResolver,
+                new DefaultJsonTypeInfoResolver()),
+        };
+
         public CosmosSystemTextJsonSerializer(JsonSerializerOptions serializerOptions = null)
         {
-            _serializerOptions = serializerOptions ?? new JsonSerializerOptions
-            {
-               
-            };
+            _serializerOptions = serializerOptions ?? CreateDefaultOptions();
         }
 
         public override T FromStream<T>(Stream stream)

--- a/src/MovieTracker.Backend/Functions/Function.cs
+++ b/src/MovieTracker.Backend/Functions/Function.cs
@@ -2,9 +2,8 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
-using Microsoft.SemanticKernel.ChatCompletion;
-using Microsoft.SemanticKernel.Connectors.OpenAI;
-using Microsoft.SemanticKernel;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
 using OpenTelemetry.Trace;
 using System.Text.Json.Serialization;
 using System.Text.Json;
@@ -13,6 +12,9 @@ using TMDbLib.Client;
 using Microsoft.Extensions.Configuration;
 using MovieTracker.Backend.Prompts;
 using MovieTracker.Backend.Agents;
+// This namespace declares its own ChatMessage - the shape returned to the frontend - which would
+// otherwise shadow the Microsoft.Extensions.AI one used for conversation state.
+using AIChatMessage = Microsoft.Extensions.AI.ChatMessage;
 
 namespace MovieTracker.Backend.Functions
 {
@@ -112,10 +114,10 @@ namespace MovieTracker.Backend.Functions
     public class ChatSession
     {
         public string Id { get; set; }
-        public ChatHistory ChatHistory { get; set; }
+        public List<AIChatMessage> ChatHistory { get; set; }
         public string? FunnyFact { get; set; }  // Funny fact at the session level
 
-        public ChatSession(string id, ChatHistory chatHistory)
+        public ChatSession(string id, List<AIChatMessage> chatHistory)
         {
             Id = id;
             ChatHistory = chatHistory;
@@ -137,9 +139,35 @@ namespace MovieTracker.Backend.Functions
         public string MovieName { get; set; }
     }
 
-    public class Function(Kernel kernel, ChatSessionRepository chatSessionRepository, IDistributedCache cache, IConfiguration configuration, ILogger<Function> logger, Tracer tracer, WikipediaSearchAgent wikipediaAgent, OpenMovieDbAgent openMovieDbAgent, TrailerAgent trailerAgent)
+    public class Function(AIAgent agent, ChatPlanner chatPlanner, ChatSessionRepository chatSessionRepository, IDistributedCache cache, IConfiguration configuration, ILogger<Function> logger, Tracer tracer)
     {
         private readonly string apiKey = configuration["TheMovieDb:Api-Key"] ?? throw new ArgumentNullException("Missing The Movice Db Api Key");
+
+        // The model must answer with MovieListResponse's exact PascalCase property names: the system
+        // prompt names "SystemMessage"/"MovieList" and ProcessMovieAsync reads "MovieId" back out.
+        // Microsoft.Extensions.AI defaults to camelCase, so the naming policy is pinned to null here -
+        // Semantic Kernel's ResponseFormat = typeof(MovieListResponse) used the declared names.
+        private static readonly JsonSerializerOptions StructuredOutputJsonOptions =
+            new(AIJsonUtilities.DefaultOptions) { PropertyNamingPolicy = null };
+
+        // Semantic Kernel's ResponseFormat = typeof(T) emitted a schema in Azure OpenAI's *strict*
+        // dialect. Microsoft.Extensions.AI does not do that by default: ChatResponseFormat.ForJsonSchema
+        // (Type, ...) produces a plain schema with no "required" array and no additionalProperties:false,
+        // which the service rejects with HTTP 400. These two transform flags restore the strict shape.
+        private static readonly ChatResponseFormat MovieListResponseFormat =
+            ChatResponseFormat.ForJsonSchema(
+                AIJsonUtilities.CreateJsonSchema(
+                    typeof(MovieListResponse),
+                    serializerOptions: StructuredOutputJsonOptions,
+                    inferenceOptions: new AIJsonSchemaCreateOptions
+                    {
+                        TransformOptions = new AIJsonSchemaTransformOptions
+                        {
+                            DisallowAdditionalProperties = true,
+                            RequireAllProperties = true,
+                        }
+                    }),
+                nameof(MovieListResponse));
 
         // Reasoning models spend most of their output budget on hidden reasoning tokens, and output
         // tokens are the expensive ones. Measured against this app's own system prompt and tool set,
@@ -200,7 +228,7 @@ namespace MovieTracker.Backend.Functions
                     Always respond only with a JSON object. Keep responses informative but concise (2-4 sentences max).
                     """;
 
-                ChatHistory chatHistory = new(systemMessage);
+                List<AIChatMessage> chatHistory = [new AIChatMessage(ChatRole.System, systemMessage)];
                 var newChatSession = await chatSessionRepository.NewChatSession(chatHistory);
                 return new OkObjectResult(new ChatSessionIdResponse(newChatSession.id));
             }
@@ -351,11 +379,6 @@ namespace MovieTracker.Backend.Functions
                     return new BadRequestObjectResult("Chat not found");
                 }
 
-                var chatPlanner = new ChatPlanner(kernel, wikipediaAgent, openMovieDbAgent, trailerAgent);
-
-                // Add the enhanced context function to kernel
-                kernel.Plugins.Add(KernelPluginFactory.CreateFromObject(chatPlanner));
-
                 //string? funnyFact = await chatPlanner.GenerateFunnyFact(ask.Input);
                 string? funnyFact = await chatPlanner.GenerateEnhancedFunnyFact(ask.Input);
 
@@ -364,41 +387,49 @@ namespace MovieTracker.Backend.Functions
                     chatSession.FunnyFact = funnyFact;
                 }
 
-                chatMessages.AddUserMessage(ask.Input);
-                IChatCompletionService chatCompletionService = kernel.GetRequiredService<IChatCompletionService>();
+                chatMessages.Add(new AIChatMessage(ChatRole.User, ask.Input));
 
-                OpenAIPromptExecutionSettings openAIPromptExecutionSettings = new()
+                // The agent already carries the tool set and invokes tools automatically, so only the
+                // per-call settings are built here. Run options are merged over the agent's defaults,
+                // and tool collections are unioned rather than replaced.
+                ChatOptions chatOptions = new()
                 {
-                    ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions,
+                    ResponseFormat = MovieListResponseFormat,
                 };
-#pragma warning disable SKEXP0010
-                openAIPromptExecutionSettings.ResponseFormat = typeof(MovieListResponse);
-#pragma warning restore SKEXP0010
+
                 if (!string.IsNullOrWhiteSpace(reasoningEffort)
                     && !string.Equals(reasoningEffort, "default", StringComparison.OrdinalIgnoreCase))
                 {
-                    openAIPromptExecutionSettings.ReasoningEffort = reasoningEffort;
-                }
-
-                var result = await chatCompletionService.GetChatMessageContentsAsync(
-                    chatMessages,
-                    executionSettings: openAIPromptExecutionSettings,
-                    kernel: kernel);
-
-                foreach (var content in result)
-                {
-                    var text = content.ToString();
-                    if (content.Role == AuthorRole.Assistant)
+                    // Deliberately not ChatOptions.Reasoning: its ReasoningEffort enum only offers
+                    // None/Low/Medium/High/ExtraHigh, and this setting has to be able to carry
+                    // model-family-specific values such as "minimal". Dropping to the provider's own
+                    // options type keeps the passthrough behaviour SK had.
+                    // OPENAI001 gates ReasoningEffortLevel as evaluation-only, the same way SKEXP0010
+                    // gated the structured-output ResponseFormat this method used to set.
+#pragma warning disable OPENAI001
+                    chatOptions.RawRepresentationFactory = _ => new OpenAI.Chat.ChatCompletionOptions
                     {
-                        chatMessages.AddAssistantMessage(text);
-                    }
+                        ReasoningEffortLevel = new OpenAI.Chat.ChatReasoningEffortLevel(reasoningEffort)
+                    };
+#pragma warning restore OPENAI001
                 }
+
+                // session: null runs the agent statelessly - the entire conversation is passed in on
+                // every call and the generated messages are appended back onto it. That is exactly what
+                // the Semantic Kernel version did with a ChatHistory, and it is what lets the response
+                // below be rebuilt by re-walking the whole conversation.
+                var result = await agent.RunAsync(chatMessages, null, new ChatClientAgentRunOptions(chatOptions));
+
+                // Includes the intermediate function-call and function-result messages as well as the
+                // final answer. They carry no text, so the loop below skips them, but they must be
+                // persisted: a tool call without its result is an invalid conversation on the next turn.
+                chatMessages.AddRange(result.Messages);
 
                 var responseMessages = new List<ChatMessage>();
                 foreach (var messages in chatMessages)
                 {
-                    var text = messages.ToString();
-                    if (messages.Role == AuthorRole.Assistant && !String.IsNullOrEmpty(text))
+                    var text = messages.Text;
+                    if (messages.Role == ChatRole.Assistant && !String.IsNullOrEmpty(text))
                     {
                         text = text.Replace("```json", "").Replace("```", "");
                         List<MovieViewModel> movieItems = new List<MovieViewModel>();
@@ -433,7 +464,7 @@ namespace MovieTracker.Backend.Functions
                         }
                     }
 
-                    if (messages.Role == AuthorRole.User && !String.IsNullOrEmpty(text))
+                    if (messages.Role == ChatRole.User && !String.IsNullOrEmpty(text))
                     {
                         UserChatMessage userChatMessage = new UserChatMessage(text);
                         responseMessages.Add(userChatMessage);

--- a/src/MovieTracker.Backend/MovieTracker.Backend.csproj
+++ b/src/MovieTracker.Backend/MovieTracker.Backend.csproj
@@ -11,10 +11,18 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
+		<!-- Supplies AzureOpenAIClient, which Microsoft.Agents.AI.OpenAI does not reference (it targets
+		     the plain OpenAI SDK). The beta line is deliberate and is what Semantic Kernel was already
+		     resolving transitively before the migration: it is the newest published, and it is built
+		     against the same OpenAI 2.10.0 that Microsoft.Extensions.AI.OpenAI requires. The last
+		     stable, 2.1.0, is pinned to OpenAI 2.1.0 and would be silently up-shifted. -->
+		<PackageReference Include="Azure.AI.OpenAI" Version="2.9.0-beta.1" />
 		<PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.1" />
 		<PackageReference Include="Azure.Identity" Version="1.21.0" />
 		<PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.6.0" />
 		<PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.8.3" />
+		<PackageReference Include="Microsoft.Agents.AI" Version="1.15.0" />
+		<PackageReference Include="Microsoft.Agents.AI.OpenAI" Version="1.15.0" />
 		<!-- Pinned to the 2.x line on purpose. Application Insights 3.x is the OpenTelemetry-based
 		     rewrite and drops ITelemetryInitializer, which Microsoft.Azure.Functions.Worker.ApplicationInsights
 		     still binds to; that package's open-ended PerfCounterCollector [2.23.0, ) range lets 3.x in and
@@ -28,12 +36,10 @@
 		<PackageReference Include="Microsoft.Azure.Functions.Worker.OpenTelemetry" Version="1.2.0" />
 		<PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.1.0" />
 		<PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.51.0" />
+		<PackageReference Include="Microsoft.Extensions.AI" Version="10.6.0" />
 		<PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.10" />
 		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
 		<PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.8.0" />
-		<PackageReference Include="Microsoft.SemanticKernel" Version="1.78.0" />
-		<PackageReference Include="Microsoft.SemanticKernel.Connectors.AzureOpenAI" Version="1.78.0" />
-		<PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.78.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 		<PackageReference Include="OmdbApiNet" Version="1.3.0" />
 		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />

--- a/src/MovieTracker.Backend/Program.cs
+++ b/src/MovieTracker.Backend/Program.cs
@@ -11,17 +11,19 @@ using Azure.Monitor.OpenTelemetry.AspNetCore;
 using Microsoft.Azure.Cosmos;
 using Azure.Core;
 using Microsoft.Extensions.Logging;
-using Microsoft.SemanticKernel;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
 using MovieTracker.Backend;
 using MovieTracker.Backend.Prompts;
 using Azure.Monitor.OpenTelemetry.Exporter;
 using OpenTelemetry.Logs;
 using MovieTracker.Backend.Agents;
+using Azure.AI.OpenAI;
+using System.ClientModel;
+using System.ClientModel.Primitives;
 
 var serviceName = "movie-tracker-backend";
 var serviceVersion = "1.0.0";
-
-AppContext.SetSwitch("Microsoft.SemanticKernel.Experimental.GenAI.EnableOTelDiagnosticsSensitive", true);
 
 var host = new HostBuilder()
     .ConfigureAppConfiguration((context, config) =>
@@ -59,7 +61,7 @@ var host = new HostBuilder()
         services.AddDistributedMemoryCache();
         services.AddApplicationInsightsTelemetryWorkerService();
         services.ConfigureFunctionsApplicationInsights();
-        // This named client is used only by the Semantic Kernel chat completion service.
+        // This named client is used only by the Azure OpenAI chat client behind the agent.
         // The standard resilience handler defaults to a 30s total / 10s per-attempt timeout,
         // which a reasoning model comfortably exceeds, so the budget is widened here.
         // Constraint: SamplingDuration must be >= 2x AttemptTimeout or options validation throws.
@@ -95,11 +97,12 @@ var host = new HostBuilder()
         services.AddScoped<WikipediaSearchAgent>();
         services.AddScoped<OpenMovieDbAgent>();
         services.AddScoped<TrailerAgent>();
-        services.AddScoped<Kernel>(serviceProvider =>
+        // The raw model connection. Registered separately from the agent because the funny-fact and
+        // trailer-title prompts in ChatPlanner/TrailerAgent must run WITHOUT the agent's tool set and
+        // JSON response format - the same reason they resolved IChatCompletionService directly off
+        // the kernel before this migration.
+        services.AddScoped<IChatClient>(serviceProvider =>
         {
-
-
-
             var azureOpenAiEndpoint = context.Configuration["AzureOpenAi:Endpoint"];
             if (string.IsNullOrEmpty(azureOpenAiEndpoint))
             {
@@ -116,43 +119,74 @@ var host = new HostBuilder()
                 throw new ConfigurationErrorsException("Missing AzureOpenAi:Deployment");
             }
 
-            var kernelBuilder = Kernel.CreateBuilder();
             var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
-            kernelBuilder.Services.AddLogging(builder =>
-            {
-                builder.AddOpenTelemetry(options =>
-                {
-                    options.SetResourceBuilder(ResourceBuilder.CreateDefault());
-                    options.AddAzureMonitorLogExporter(options => options.ConnectionString = context.Configuration["APPLICATIONINSIGHTS-CONNECTION-STRING"]);
-                    options.IncludeFormattedMessage = true;
-                    options.IncludeScopes = true;
-                });
-                builder.AddFilter("Microsoft", LogLevel.Warning);
-                builder.AddFilter("Microsoft.SemanticKernel", LogLevel.Information);
-                builder.SetMinimumLevel(LogLevel.Information);
-            });
-            var configuration = serviceProvider.GetRequiredService<IConfiguration>();
-            kernelBuilder.Services.AddSingleton(configuration);
             IHttpClientFactory httpClientFactory = serviceProvider.GetRequiredService<IHttpClientFactory>();
             var httpClient = httpClientFactory.CreateClient("HttpClient");
-            kernelBuilder.AddAzureOpenAIChatCompletion(
-                deploymentName: azureOpenAiDeployment,
-                endpoint: azureOpenAiEndpoint,
-                apiKey: azureOpenAiApiKey,
-                httpClient: httpClient);
-            kernelBuilder.Plugins.AddFromType<TheMovieDBKernelFunctions>();
-            kernelBuilder.Plugins.AddFromType<DateTimeKernelFunctions>();
 
-            //kernelBuilder.Plugins.AddFromType<ChatPlanner>();
-            var kernel = kernelBuilder.Build();
-            return kernel;
+            // Routing the Azure SDK pipeline through the named HttpClient is what preserves the
+            // widened resilience timeouts configured above; AddAzureOpenAIChatCompletion took the
+            // HttpClient directly.
+            var clientOptions = new AzureOpenAIClientOptions
+            {
+                Transport = new HttpClientPipelineTransport(httpClient)
+            };
+            var azureOpenAiClient = new AzureOpenAIClient(
+                new Uri(azureOpenAiEndpoint),
+                new ApiKeyCredential(azureOpenAiApiKey),
+                clientOptions);
 
+            // GetChatClient returns the OpenAI SDK's ChatClient, not an IChatClient - AsIChatClient
+            // is the required adapter.
+            return azureOpenAiClient
+                .GetChatClient(azureOpenAiDeployment)
+                .AsIChatClient()
+                .AsBuilder()
+                // Replaces the Microsoft.SemanticKernel.Experimental.GenAI.EnableOTelDiagnosticsSensitive
+                // AppContext switch: emits GenAI spans and includes prompts and completions in them.
+                .UseOpenTelemetry(loggerFactory, serviceName, options => options.EnableSensitiveData = true)
+                .Build(serviceProvider);
+        });
+
+        services.AddScoped<TheMovieDBKernelFunctions>();
+        services.AddScoped<ChatPlanner>();
+
+        // The agent replaces the Kernel. Semantic Kernel discovered tools by attribute at build time
+        // (Plugins.AddFromType) and had ChatPlanner bolted on per request; the Agent Framework takes
+        // one explicit tool list, so all three sources are unioned here instead.
+        services.AddScoped<AIAgent>(serviceProvider =>
+        {
+            var chatClient = serviceProvider.GetRequiredService<IChatClient>();
+            var theMovieDbFunctions = serviceProvider.GetRequiredService<TheMovieDBKernelFunctions>();
+            var chatPlanner = serviceProvider.GetRequiredService<ChatPlanner>();
+
+            List<AITool> tools =
+            [
+                .. theMovieDbFunctions.CreateTools(),
+                .. DateTimeKernelFunctions.CreateTools(),
+                .. chatPlanner.CreateTools(),
+            ];
+
+            // ChatClientAgent decorates the chat client with automatic function invocation by default,
+            // which is what ToolCallBehavior.AutoInvokeKernelFunctions used to switch on.
+            return chatClient.AsAIAgent(
+                new ChatClientAgentOptions
+                {
+                    Name = serviceName,
+                    ChatOptions = new ChatOptions { Tools = tools },
+                },
+                serviceProvider.GetRequiredService<ILoggerFactory>(),
+                serviceProvider);
         });
         services.AddOpenTelemetry()
                  .WithTracing((builder) =>
                  {
+                     // serviceName also covers the model spans: it is the source name passed to
+                     // UseOpenTelemetry on the chat client above.
                      builder.AddSource(serviceName)
-                            .AddSource("Microsoft.SemanticKernel*")
+                            .AddSource("Microsoft.Extensions.AI*")
+                            .AddSource("Microsoft.Agents.AI*")
+                            .AddSource("Azure.AI.OpenAI*")
+                            .AddSource("OpenAI*")
                             .SetResourceBuilder(ResourceBuilder.CreateDefault()
                             .AddService(serviceName: serviceName, serviceVersion: serviceVersion))
                             .AddAspNetCoreInstrumentation()

--- a/src/MovieTracker.Backend/Prompts/ChatPlanner.cs
+++ b/src/MovieTracker.Backend/Prompts/ChatPlanner.cs
@@ -1,27 +1,51 @@
-﻿using Microsoft.SemanticKernel;
-using Microsoft.SemanticKernel.ChatCompletion;
+using Microsoft.Extensions.AI;
 using MovieTracker.Backend.Agents;
 using System.ComponentModel;
 using System.Text.Json;
 
 namespace MovieTracker.Backend.Prompts
 {
+    /// <summary>
+    /// The facade the model sees over the Agents/ services - ratings, trailers and the
+    /// Wikipedia-backed funny facts and context. Under Semantic Kernel this was turned into a plugin
+    /// per request with KernelPluginFactory.CreateFromObject; the Agent Framework equivalent is the
+    /// explicit CreateTools() list below, which Program.cs folds into the agent's tool set.
+    /// </summary>
     public class ChatPlanner
     {
-        private readonly Kernel kernel;
+        // The bare IChatClient, not the AIAgent: these are single-shot prompts that must not inherit
+        // the agent's tool set or its JSON response format. See the note on TrailerAgent.chatClient.
+        private readonly IChatClient chatClient;
         private readonly WikipediaSearchAgent wikipediaAgent;
         private readonly OpenMovieDbAgent openMovieDbAgent;
         private readonly TrailerAgent trailerAgent;
 
-        public ChatPlanner(Kernel kernel, WikipediaSearchAgent wikipediaAgent, OpenMovieDbAgent openMovieDbAgent, TrailerAgent trailerAgent)
+        public ChatPlanner(IChatClient chatClient, WikipediaSearchAgent wikipediaAgent, OpenMovieDbAgent openMovieDbAgent, TrailerAgent trailerAgent)
         {
-            this.kernel = kernel;
+            this.chatClient = chatClient;
             this.wikipediaAgent = wikipediaAgent;
             this.openMovieDbAgent = openMovieDbAgent;
             this.trailerAgent = trailerAgent;
         }
 
-        [KernelFunction]
+        /// <summary>
+        /// Explicit tool list; see the note on TheMovieDBKernelFunctions.CreateTools. This is the same
+        /// set of methods that carried [KernelFunction] before the migration.
+        /// </summary>
+        public IEnumerable<AITool> CreateTools() =>
+        [
+            AIFunctionFactory.Create(HandleTrailerRequest),
+            AIFunctionFactory.Create(GetMovieRating),
+            AIFunctionFactory.Create(CompareMovieRatings),
+            AIFunctionFactory.Create(FilterMoviesByRating),
+            AIFunctionFactory.Create(GetMovieRatingGeneric),
+            AIFunctionFactory.Create(GenerateEnhancedFunnyFact),
+            AIFunctionFactory.Create(GetChatContext),
+            AIFunctionFactory.Create(GenerateFunnyFact),
+            AIFunctionFactory.Create(GenerateRequiredSteps),
+            AIFunctionFactory.Create(GetMovieContext),
+        ];
+
         [Description("Handle trailer requests and return clickable trailer links")]
         public async Task<string> HandleTrailerRequest(string userQuery)
         {
@@ -33,7 +57,6 @@ namespace MovieTracker.Backend.Prompts
             return await GenerateRequiredSteps();
         }
 
-        [KernelFunction]
         [Description("Get movie rating (defaults to IMDb rating) for a specific movie using its IMDb ID. Always returns IMDb rating as the primary rating.")]
         [return: Description("JSON object containing IMDb rating as the primary rating, with other ratings as additional context")]
         public async Task<string> GetMovieRating(
@@ -58,7 +81,6 @@ namespace MovieTracker.Backend.Prompts
             });
         }
 
-        [KernelFunction]
         [Description("Compare IMDb ratings of multiple movies and find the highest rated one. Always uses IMDb ratings for comparison.")]
         [return: Description("Comparison results showing which movie has the highest IMDb rating")]
         public async Task<string> CompareMovieRatings(
@@ -87,7 +109,6 @@ namespace MovieTracker.Backend.Prompts
             });
         }
 
-        [KernelFunction]
         [Description("Filter movies by IMDb rating threshold. Always uses IMDb ratings for filtering.")]
         [return: Description("List of movies that meet the minimum IMDb rating requirement")]
         public async Task<string> FilterMoviesByRating(
@@ -114,7 +135,6 @@ namespace MovieTracker.Backend.Prompts
             });
         }
 
-        [KernelFunction]
         [Description("Get rating for a movie (uses IMDb rating as default). Use this when user asks about 'rating' without specifying the source.")]
         [return: Description("Movie rating information with IMDb rating as the primary rating")]
         public async Task<string> GetMovieRatingGeneric(
@@ -144,7 +164,6 @@ namespace MovieTracker.Backend.Prompts
             });
         }
 
-        [KernelFunction]
         [Description("Enhanced funny fact generator using Wikipedia data")]
         public async Task<string?> GenerateEnhancedFunnyFact(string userQuery)
         {
@@ -163,16 +182,13 @@ namespace MovieTracker.Backend.Prompts
                 Generate ONE surprising, entertaining fact that most people wouldn't know.
                 Keep it under 100 characters and make it engaging for movie fans.
                 ";
-
-                var chatService = kernel.GetRequiredService<IChatCompletionService>();
-                var result = await chatService.GetChatMessageContentAsync(enhancedPrompt);
-                return result.Content?.Trim();
+                var result = await chatClient.GetResponseAsync(enhancedPrompt);
+                return result.Text?.Trim();
             }
 
             return await GenerateBasicFunnyFact(detectedEntity);
         }
 
-        [KernelFunction]
         [Description("Gets detailed information about movies/actors for chat context")]
         public async Task<string?> GetChatContext(string entityName, string entityType = "movie")
         {
@@ -189,7 +205,6 @@ namespace MovieTracker.Backend.Prompts
             });
         }
 
-        [KernelFunction]
         [Description("Detects if user query mentions specific actors/movies and generates a funny fact")]
         [return: Description("A funny fact if entities are detected, null otherwise")]
         public async Task<string?> GenerateFunnyFact(string userQuery)
@@ -211,10 +226,8 @@ namespace MovieTracker.Backend.Prompts
             Query: 'what popular movies came out last year' -> 'NONE'
             Query: 'movies directed by Christopher Nolan' -> 'Christopher Nolan'
             ";
-
-            var chatService = kernel.GetRequiredService<IChatCompletionService>();
-            var detectionResult = await chatService.GetChatMessageContentAsync(entityDetectionPrompt);
-            var detectedEntity = detectionResult.Content?.Trim() ?? "NONE";
+            var detectionResult = await chatClient.GetResponseAsync(entityDetectionPrompt);
+            var detectedEntity = detectionResult.Text?.Trim() ?? "NONE";
 
             if (detectedEntity.ToUpper() == "NONE")
             {
@@ -232,11 +245,10 @@ namespace MovieTracker.Backend.Prompts
             - Christopher Nolan doesn't use email or a smartphone.
             ";
 
-            var funnyFactResult = await chatService.GetChatMessageContentAsync(funnyFactPrompt);
-            return funnyFactResult.Content?.Trim();
+            var funnyFactResult = await chatClient.GetResponseAsync(funnyFactPrompt);
+            return funnyFactResult.Text?.Trim();
         }
 
-        [KernelFunction]
         [Description("Returns instructions on how best to respond to the user")]
         [return: Description("The list of steps to best respond to the user")]
         public async Task<string> GenerateRequiredSteps()
@@ -281,10 +293,8 @@ namespace MovieTracker.Backend.Prompts
         Query: 'what popular movies came out last year' -> 'NONE'
         Query: 'movies directed by Christopher Nolan' -> 'Christopher Nolan'
         ";
-
-            var chatService = kernel.GetRequiredService<IChatCompletionService>();
-            var detectionResult = await chatService.GetChatMessageContentAsync(entityDetectionPrompt);
-            return detectionResult.Content?.Trim() ?? "NONE";
+            var detectionResult = await chatClient.GetResponseAsync(entityDetectionPrompt);
+            return detectionResult.Text?.Trim() ?? "NONE";
         }
 
         private async Task<string?> GenerateBasicFunnyFact(string detectedEntity)
@@ -299,13 +309,10 @@ namespace MovieTracker.Backend.Prompts
         - The Matrix's famous green code is actually sushi recipes in Japanese.
         - Christopher Nolan doesn't use email or a smartphone.
         ";
-
-            var chatService = kernel.GetRequiredService<IChatCompletionService>();
-            var funnyFactResult = await chatService.GetChatMessageContentAsync(funnyFactPrompt);
-            return funnyFactResult.Content?.Trim();
+            var funnyFactResult = await chatClient.GetResponseAsync(funnyFactPrompt);
+            return funnyFactResult.Text?.Trim();
         }
 
-        [KernelFunction]
         [Description("Provides rich context about movies/actors for enhanced responses")]
         public async Task<string?> GetMovieContext(string userQuery)
         {
@@ -326,10 +333,8 @@ namespace MovieTracker.Backend.Prompts
             Focus on surprising details, cultural impact, or behind-the-scenes stories.
             Keep it concise but engaging.
             ";
-
-                var chatService = kernel.GetRequiredService<IChatCompletionService>();
-                var result = await chatService.GetChatMessageContentAsync(contextPrompt);
-                return result.Content?.Trim();
+                var result = await chatClient.GetResponseAsync(contextPrompt);
+                return result.Text?.Trim();
             }
 
             return null;

--- a/src/MovieTracker.Backend/Prompts/DateTimeKernelFunctions.cs
+++ b/src/MovieTracker.Backend/Prompts/DateTimeKernelFunctions.cs
@@ -1,4 +1,4 @@
-using Microsoft.SemanticKernel;
+using Microsoft.Extensions.AI;
 using System;
 using System.ComponentModel;
 using System.Globalization;
@@ -7,18 +7,32 @@ namespace MovieTracker.Backend.Prompts
 {
     public class DateTimeKernelFunctions
     {
+        /// <summary>
+        /// Explicit tool list; see the note on TheMovieDBKernelFunctions.CreateTools.
+        /// These are static methods, so no instance is captured.
+        /// </summary>
+        public static IEnumerable<AITool> CreateTools() =>
+        [
+            AIFunctionFactory.Create(Today),
+            AIFunctionFactory.Create(ThisMonth),
+            AIFunctionFactory.Create(ThisYear),
+            AIFunctionFactory.Create(PastYearsRange),
+            AIFunctionFactory.Create(PastMonthsRange),
+            AIFunctionFactory.Create(PastDaysRange),
+            AIFunctionFactory.Create(OffsetDate),
+        ];
+
         // ---------- POINTS ----------
-        [KernelFunction, Description("Today in ISO format (YYYY-MM-DD)")]
+        [Description("Today in ISO format (YYYY-MM-DD)")]
         public static string Today() => DateTime.UtcNow.ToString("yyyy-MM-dd");
 
-        [KernelFunction, Description("This month (first day) in ISO format (YYYY-MM)")]
+        [Description("This month (first day) in ISO format (YYYY-MM)")]
         public static string ThisMonth() => DateTime.UtcNow.ToString("yyyy-MM");
 
-        [KernelFunction, Description("This year in ISO format (YYYY)")]
+        [Description("This year in ISO format (YYYY)")]
         public static string ThisYear() => DateTime.UtcNow.Year.ToString();
 
         // ---------- RANGES ----------
-        [KernelFunction]
         [Description("ISO-8601 interval for the past <years> full years up to today. " +
                      "Example: PastYearsRange(3) → 2022-06-13/2025-06-13")]
         public static string PastYearsRange(
@@ -30,7 +44,6 @@ namespace MovieTracker.Backend.Prompts
             return $"{start:yyyy-MM-dd}/{end:yyyy-MM-dd}";
         }
 
-        [KernelFunction]
         [Description("ISO-8601 interval for the past <months> full months up to today. " +
                      "Example: PastMonthsRange(6) → 2024-12-13/2025-06-13")]
         public static string PastMonthsRange(int months)
@@ -40,7 +53,6 @@ namespace MovieTracker.Backend.Prompts
             return $"{start:yyyy-MM-dd}/{end:yyyy-MM-dd}";
         }
 
-        [KernelFunction]
         [Description("ISO-8601 interval for the past <days> days up to today.")]
         public static string PastDaysRange(int days)
         {
@@ -50,7 +62,6 @@ namespace MovieTracker.Backend.Prompts
         }
 
         // ---------- GENERIC ----------
-        [KernelFunction]
         [Description("Offset any ISO date (YYYY-MM-DD) by N units. Units = d, m, y. " +
                      "Example: OffsetDate(\"2022-05-20\", 10, \"d\")")]
         public static string OffsetDate(

--- a/src/MovieTracker.Backend/Prompts/TheMovieDBKernelFunctions.cs
+++ b/src/MovieTracker.Backend/Prompts/TheMovieDBKernelFunctions.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.Extensions.Configuration;
-using Microsoft.SemanticKernel;
+﻿using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Configuration;
 using System.ComponentModel;
 using System.Text.Json;
 using TMDbLib.Client;
@@ -14,6 +14,27 @@ namespace MovieTracker.Backend.Prompts
     {
         private readonly string apiKey = configuration["TheMovieDb:Api-Key"] ?? throw new ArgumentNullException("Missing The Movice Db Api Key");
         private record MovieItem(string MovieId, string MovieName);
+
+        /// <summary>
+        /// The Agent Framework has no equivalent of SK's Plugins.AddFromType&lt;T&gt;(), which discovered
+        /// methods by their [KernelFunction] attribute. Tools are now an explicit list, so this method
+        /// is the single place that decides which methods the model can call. Adding a method below
+        /// without adding it here leaves it invisible to the model.
+        /// [Description] attributes still drive the schema handed to the model, exactly as before.
+        /// </summary>
+        public IEnumerable<AITool> CreateTools() =>
+        [
+            AIFunctionFactory.Create(GetGenresList),
+            AIFunctionFactory.Create(SearchForPeople),
+            AIFunctionFactory.Create(SearchMovies),
+            AIFunctionFactory.Create(GetMovieTrailers),
+            AIFunctionFactory.Create(GetMovieWithTrailer),
+            AIFunctionFactory.Create(HandleGenericTrailerRequest),
+            AIFunctionFactory.Create(GetMovieDetails),
+            AIFunctionFactory.Create(SearchKeywords),
+            AIFunctionFactory.Create(DescribeMovie),
+            AIFunctionFactory.Create(DiscoverMovies),
+        ];
 
         /// <summary>
         /// The model frequently invents ids like "1990-Joe-Versus-the-Volcano" instead of reusing
@@ -47,7 +68,6 @@ namespace MovieTracker.Backend.Prompts
                .Select(parsed => parsed!.Value)
                .ToList();
 
-        [KernelFunction]
         [Description("Get the list of official genres for movies.")]
         [return: Description("a json list of official genres for movies, with the following properties GenreId and the GenreName")]
         public async Task<string> GetGenresList()
@@ -59,7 +79,6 @@ namespace MovieTracker.Backend.Prompts
         }
 
         public record PersonSearchResult(string PersonId, string PersonName);
-        [KernelFunction]
         [Description("Search for people / cast by their name and also known as names.")]
         [return: Description("a json list of people with the following properties PersonId and the PersonName")]
         public async Task<string> SearchForPeople(
@@ -71,7 +90,6 @@ namespace MovieTracker.Backend.Prompts
             return JsonSerializer.Serialize(personSearchResults);
         }
 
-        [KernelFunction]
         [Description("Search for movies by their title and release year. Use this to find movies, you can search by movie name or part of a movie name")]
         [return: Description("a json list of movies with the following properties MovieId, MovieName, ReleaseDate, and ImdbId")]
         public async Task<string> SearchMovies(
@@ -99,7 +117,6 @@ namespace MovieTracker.Backend.Prompts
             return JsonSerializer.Serialize(movieSearchResults);
         }
 
-        [KernelFunction]
         [Description("Get movie trailers, teasers, video clips, behind-the-scenes content, and interviews for a specific movie. Use this when users ask to 'show trailer', 'play trailer', 'watch video', 'preview movie', 'see teaser', 'video content', 'behind-the-scenes', or any video-related requests for a movie.")]
         [return: Description("JSON object containing all available video content including trailers, teasers, clips, and behind-the-scenes footage")]
         public async Task<string> GetMovieTrailers(
@@ -152,7 +169,6 @@ namespace MovieTracker.Backend.Prompts
             });
         }
 
-        [KernelFunction]
         [Description("Get movie information with trailer included for inline chat display. Use when users ask to 'show movie', 'tell me about movie', or want general movie info that should include a trailer preview.")]
         [return: Description("Complete movie information with embedded trailer for chat display")]
         public async Task<string> GetMovieWithTrailer(
@@ -202,7 +218,6 @@ namespace MovieTracker.Backend.Prompts
             });
         }
 
-        [KernelFunction]
         [Description("Handle generic video/trailer requests when context is unclear. Use for queries like 'trailer please', 'play trailer', 'watch video', 'movie trailer?' when no specific movie is mentioned.")]
         [return: Description("Response asking for clarification about which movie trailer they want")]
         public async Task<string> HandleGenericTrailerRequest(
@@ -222,7 +237,6 @@ namespace MovieTracker.Backend.Prompts
             });
         }
 
-        [KernelFunction]
         [Description("Get detailed information about a specific movie by its ID.")]
         [return: Description("Detailed information about the movie, including title, overview, release date, genres, runtime, and ImdbId.")]
         public async Task<string> GetMovieDetails(
@@ -251,7 +265,6 @@ namespace MovieTracker.Backend.Prompts
             return JsonSerializer.Serialize(movieDetails);
         }
 
-        [KernelFunction]
         [Description("Search for keywords related to movies.")]
         [return: Description("A JSON list of keywords with their properties such as KeywordId and Name.")]
         public async Task<string> SearchKeywords(
@@ -263,7 +276,6 @@ namespace MovieTracker.Backend.Prompts
             return JsonSerializer.Serialize(keywordList);
         }
 
-        [KernelFunction]
         [Description("Returns detailed information about a specific movie in a serialized format")]
         [return: Description("Serialized JSON containing information about a specific movie including ImdbId")]
         public async Task<string> DescribeMovie([Description("The movie ID of a specific movie")] string movieId)
@@ -296,7 +308,6 @@ namespace MovieTracker.Backend.Prompts
             return movieJson;
         }
 
-        [KernelFunction]
         [Description("Discover movies based on various filters and sort options.")]
         [return: Description("A JSON list of movies with their properties such as MovieId, MovieName, ReleaseDate, and ImdbId.")]
         public async Task<string> DiscoverMovies(


### PR DESCRIPTION
Lift and shift to Microsoft.Agents.AI 1.15.0 with no feature changes and no change to the HTTP API. Semantic Kernel is fully removed.

- Kernel (scoped DI) -> IChatClient + AIAgent, both scoped. ChatPlanner and TrailerAgent take the bare IChatClient rather than the agent, because their prompts must run without the agent's tool set and JSON response format - the same reason they resolved IChatCompletionService off the kernel before.
- Plugins.AddFromType<T>() has no equivalent, so the 27 [KernelFunction] methods become explicit CreateTools() lists built with AIFunctionFactory. [Description] attributes still drive the schema.
- ToolCallBehavior.AutoInvokeKernelFunctions is now the ChatClientAgent default.
- ChatHistory -> List<Microsoft.Extensions.AI.ChatMessage>. Chat-Ask runs with session: null, i.e. statelessly, passing the whole conversation in and appending result.Messages back, which is what the SK version did and what lets the response be rebuilt by re-walking the conversation.

Two things a clean build does not catch, both found by a parity harness run against the real production types:

- ChatResponseFormat.ForJsonSchema(typeof(T), ...) emits a schema with no "required" array and no additionalProperties:false, which Azure OpenAI strict structured outputs reject with HTTP 400. SK's ResponseFormat = typeof(T) emitted the strict dialect. Rebuilt via AIJsonSchemaTransformOptions.
- Microsoft.Extensions.AI defaults to camelCase. PropertyNamingPolicy is pinned to null for the response schema (the system prompt and ProcessMovieAsync depend on PascalCase SystemMessage/MovieList/MovieId) and for the Cosmos serializer (which would otherwise rename PartitionKey). That serializer also needs AIJsonUtilities.DefaultOptions to round-trip polymorphic AIContent.

Reasoning effort goes through ChatOptions.RawRepresentationFactory rather than ChatOptions.Reasoning, whose ReasoningEffort enum cannot express "minimal".

Azure.AI.OpenAI is pinned to 2.9.0-beta.1, the version SK already resolved transitively; stable 2.1.0 targets OpenAI 2.1.0 and conflicts with the 2.10.0 that Microsoft.Extensions.AI.OpenAI requires.

Verified against the live deployment: all queries 200 with correct titles, [TRAILER] tags intact, funny facts present, and a two-turn conversation resolving a follow-up - exercising session persistence and tool invocation. Latency is at parity; a same-session A/B measured SK at 33.3s/33.6s warm over the three benchmark queries and this build at 35.3s/36.4s then 31.2s/32.1s.

Known effect on live data: chat sessions created before this commit cannot be loaded, because the persisted message shape changed. New sessions are fine and the external contract is unchanged.