### PR TITLE
Optimise the Agent Framework request path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,31 +49,65 @@ CI does not build or test — `.github/workflows/pr-function.yml` deploys an eph
 
 ### Request flow
 
-Two HTTP functions, both in `Functions/Function.cs`:
+Three HTTP functions, all in `Functions/Function.cs`:
 
-- `Chat-Start` (`GET /api/chat/start`) — creates a `List<ChatMessage>` seeded with the **system prompt defined inline in this method**, persists it to Cosmos, returns a short `chatId`. That prompt is the contract for the whole app: it forces the model to reply with a JSON object of `SystemMessage` + `MovieList[{MovieId, MovieName}]`, and to wrap trailer URLs in `[TRAILER]...[/TRAILER]` for the frontend to render inline. Changing response shape means changing this prompt *and* the `MovieListResponse` type used as the structured-output schema.
-- `Chat-Ask` (`POST /api/chat/{chatId}/ask`) — loads the session, runs the planner, calls `agent.RunAsync(...)` with the `MovieListResponse` structured-output format, then **hydrates** the returned `MovieId`s.
+- `Chat-Start` (`GET /api/chat/start`) — creates a `List<ChatMessage>` seeded with the **system prompt defined inline in this method**, persists it to Cosmos, returns a short `chatId`. That prompt is the contract for the whole app: it forces the model to reply with a JSON object of `SystemMessage` + `MovieList[{MovieId, MovieName}]`, wrap trailer URLs in `[TRAILER]...[/TRAILER]` for the frontend to render inline, and treat **IMDb as the default rating** (see "Ratings default to IMDb" below). Changing response shape means changing this prompt *and* the `MovieListResponse` type used as the structured-output schema. The prompt is stored per session at `/start`, so edits only affect sessions created afterwards.
+- `Chat-Ask` (`POST /api/chat/{chatId}/ask`) — loads the session, runs the turn, then **hydrates** the returned `MovieId`s for the *entire* transcript, which is what this route returns.
+- `Chat-Ask-V2` (`POST /api/chat/{chatId}/ask/v2`) — identical turn and identical persistence, but returns `{ FunnyFact, Turn }` — only the assistant turn just produced, hydrated once. Purely additive; v1 is untouched and the two can be interleaved on one session because both read and write the same stored history.
+
+Both ask routes share `RunTurnAsync`. They differ only in how much of the conversation they hydrate afterwards.
 
 **Structured-output trap.** `MovieListResponseFormat` in `Function.cs` is built with `AIJsonUtilities.CreateJsonSchema` and `AIJsonSchemaTransformOptions { DisallowAdditionalProperties = true, RequireAllProperties = true }`, not with the obvious `ChatResponseFormat.ForJsonSchema(typeof(MovieListResponse), ...)`. The convenient overload emits a schema with no `required` array and no `additionalProperties: false`, which Azure OpenAI's strict structured outputs reject with HTTP 400 — Semantic Kernel's `ResponseFormat = typeof(T)` used to emit the strict dialect for you. The serializer options also pin `PropertyNamingPolicy = null`, because Microsoft.Extensions.AI defaults to camelCase and the system prompt and `ProcessMovieAsync` both depend on PascalCase `SystemMessage`/`MovieList`/`MovieId`.
 
-Hydration is the key two-layer design: the LLM only ever returns TMDb movie IDs; `ProcessMovieAsync` fans out over them, calls TMDbLib for full details plus the best YouTube trailer, and builds the `MovieViewModel` the frontend consumes. Results are cached per `movieId` in `IDistributedCache` (registered as `AddDistributedMemoryCache` — in-process, per-instance, no expiry set).
+Hydration is the key two-layer design: the LLM only ever returns TMDb movie IDs; `ProcessMovieAsync` fans out over them, calls TMDbLib for full details plus the best YouTube trailer, and builds the `MovieViewModel` the frontend consumes. Lookup is three tiers, in order:
 
-Note that `Chat-Ask` re-walks and re-hydrates the *entire* chat history on every call, so latency and TMDb calls grow with conversation length. A single `/ask` currently takes roughly 5–10s in production.
+1. `MoviceTrackerChatSession.HydratedMovies` — a `Dictionary<string, MovieViewModel>` **stored in the session's own Cosmos document**, so it arrives free with the load at the top of the request and survives restarts and scale-out. Capped at `HydratedMovieLimit` (150) purely to bound document size; anything evicted is simply re-fetched.
+2. `IDistributedCache` — `AddDistributedMemoryCache`, so process-wide and shared across sessions, but cold on every new instance.
+3. TMDb — two round trips per movie (details + videos).
+
+Tier 1 is what stops `/ask` re-fetching every movie of every past turn from TMDb on every call. Without it, TMDb traffic grows with conversation length and is cold on each new instance. A single `/ask` runs roughly 5–10s.
+
+**What is stored and what is sent are deliberately different.** Cosmos keeps every message forever because `/ask` replays the whole transcript to the frontend; the model sees a compacted view built per call by `ContextReducer`. See "Context compaction" below.
+
+The funny fact is generated **concurrently** with the main model call, not before it. It only reads the user's raw input, and running it first put two completions plus a Wikipedia REST fetch and a Wikidata SPARQL query on the critical path. `SafeGenerateFunnyFactAsync` swallows its own failures — decorative output must not fail the turn, and a task nobody awaits until later must not fault unobserved.
 
 Anything the model supplies — movie ids, release years, cast/genre/keyword id lists — is treated as untrusted input. It routinely invents non-numeric ids, so parsing goes through `TryGetTmdbId`/`ParseIdList` in `TheMovieDBKernelFunctions`, which hand the model a correctable error instead of throwing; `SafeProcessMovieAsync` isolates per-movie hydration so one bad entry cannot fail the whole response. A bare `int.Parse` on a model-supplied value is a bug waiting to happen.
 
-The named `"HttpClient"` in `Program.cs` is used **only** by the Azure OpenAI chat client (Cosmos takes the unnamed default), and its resilience timeouts are widened well past the 30s default because reasoning models are slow. They stay inside the platform's ~230s hard limit on HTTP triggers. It reaches the SDK through `AzureOpenAIClientOptions.Transport = new HttpClientPipelineTransport(httpClient)` — if that is dropped, the widened timeouts silently stop applying.
+The named `"HttpClient"` in `Program.cs` is used **only** by the Azure OpenAI chat client (Cosmos takes the unnamed default), and its resilience timeouts are widened well past the 30s default because reasoning models are slow. They stay inside the platform's ~230s hard limit on HTTP triggers. It reaches the SDK through `AzureOpenAIClientOptions.Transport = new HttpClientPipelineTransport(httpClient)` — if that is dropped, the widened timeouts silently stop applying. `Retry.MaxRetryAttempts` is 3 rather than the previous 1 because the funny-fact and main calls now fire together, which is burstier against the 200K TPM cap; the standard handler already counts 408/429/5xx as transient and honours `Retry-After`, so no custom predicate is needed.
+
+### Context compaction
+
+`ContextReducer` in `Function.cs` reduces the conversation *sent to the model* while the full history stays in Cosmos. It is a `PipelineCompactionStrategy` of `ToolResultCompactionStrategy` (collapse old tool-call groups) then `SlidingWindowCompactionStrategy` (drop oldest turns past `MaxModelTurns`), bridged to a plain message list with `.AsChatReducer()`.
+
+Things worth knowing before touching it:
+
+- **`CompactionMessageIndex` is not public.** The strategies operate on it, but the only supported way to run one over a `List<ChatMessage>` is `AsChatReducer()`. There is no public `CompactionMessageIndex.Create`.
+- The whole `Microsoft.Agents.AI.Compaction` namespace is gated behind **`MAAI001`** (evaluation-only) and is the one preview API this project depends on. The pragmas are scoped, the way `OPENAI001` is around `ReasoningEffortLevel`.
+- **The default `ToolCallFormatter` is close to useless here.** It inlines every tool result verbatim, which is fine for `"Sunny and 72F"` and not for a twenty-movie `DiscoverMovies` array — measured on a synthetic six-turn conversation it reduced context by 3%. The custom `SummariseToolCalls` truncates each result to `CollapsedToolResultChars` and gets 68% on the same input (41% at two turns, 90% at thirty).
+- Reduction runs over a **copy** of the stored list. The strategies rewrite the list they are given; if that reached `chatSession.ChatHistory`, the `/ask` transcript would quietly start losing turns.
+- Compaction always runs over the full stored history, never over its own output, so it never compounds: turn 20 sees the same reduction of turns 1–10 that turn 11 saw.
+- Safe by construction, and verified: system message preserved, every user question and assistant answer preserved inside the window, and tool calls never separated from their results (the index groups an assistant call plus its results atomically).
+
+### Ratings default to IMDb
+
+IMDb-as-default is a deliberate product decision, and it is carried in three places that must agree — the system prompt's "Ratings" block, `ChatPlanner.GetMovieRating`'s `[Description]`, and the field names in the TMDb tool payloads. `DescribeMovie` used to return TMDb's vote average under the bare name `Rating`, which invited the model to answer "which had the highest rating?" straight from it; it is now `TmdbVoteAverage`.
+
+Measured on the same "Nolan sci-fi → which had the highest rating?" pair, six passes each: **3/6 answered from IMDb before these changes, 6/6 after.** The failure mode is pre-existing model non-determinism, not something the tool pruning introduced — confirm with a `git stash` A/B before concluding otherwise.
 
 ### Agent Framework wiring
 
 `Program.cs` registers two things as **scoped**:
 
 - `IChatClient` — `AzureOpenAIClient(...).GetChatClient(deployment).AsIChatClient()`, against **Azure OpenAI in Microsoft Foundry** (`gpt-5-4-mini`, see `infrastructure/ai-foundry.bicep`), wrapped in `.UseOpenTelemetry(..., EnableSensitiveData = true)`. `GetChatClient` returns the *OpenAI SDK* `ChatClient`, so `AsIChatClient()` is mandatory — omitting it is compile error CS1929.
-- `AIAgent` — `chatClient.AsAIAgent(...)` with the full tool list. `ChatClientAgent` decorates the chat client with automatic function invocation by default, which is what `ToolCallBehavior.AutoInvokeKernelFunctions` used to do.
+- `AIAgent` — `chatClient.AsAIAgent(...)` with the full tool list, then `.AsBuilder().Use(...).Build(...)`. `ChatClientAgent` decorates the chat client with automatic function invocation by default, which is what `ToolCallBehavior.AutoInvokeKernelFunctions` used to do.
+
+The `.Use(...)` is function-invocation middleware that caps the tool-calling loop at `MaxToolIterations` (12) by setting `FunctionInvocationContext.Terminate`. `FunctionInvokingChatClient` allows **40** iterations by default, which at a few seconds per round trip blows through the 120s HttpClient budget and then the ~230s trigger limit before it gives up — the caller gets a timeout instead of an answer. Note `AsBuilder().Build()` returns a **new** agent; registering the pre-builder one silently skips the middleware.
 
 **The split matters.** `ChatPlanner` and `TrailerAgent` take the bare `IChatClient`, *not* the agent, because their prompts (entity detection, funny facts, trailer-title extraction) must run without the agent's tool set and JSON response format. Under Semantic Kernel they resolved `IChatCompletionService` off the kernel for the same reason.
 
 There is no attribute-driven tool discovery any more. `Plugins.AddFromType<T>()` is replaced by explicit `CreateTools()` methods returning `IEnumerable<AITool>` built with `AIFunctionFactory.Create`, and `Program.cs` unions the three sources. **Adding a `[Description]`-annotated method without adding it to the matching `CreateTools()` leaves it invisible to the model** — this is the single easiest thing to get wrong.
+
+The model sees **23** tools. Four `ChatPlanner` methods are deliberately *not* offered, and the `CreateTools()` XML doc says why: `GenerateEnhancedFunnyFact` and `GenerateFunnyFact` (the app already runs the enhanced one out of band; as tools they cost two nested completions plus Wikipedia/Wikidata inside a call the model is waiting on, and the fact reaches the client through the response's own field), `GenerateRequiredSteps` (a fixed string restating a JSON shape the system prompt states and the strict schema enforces), and `GetMovieRatingGeneric` (same input and same lookup as `GetMovieRating`). The methods still exist and are still called — just not by the model. The seven date helpers were kept on purpose: their schemas are tiny and they exist precisely to stop the model inventing date ranges.
 
 - `Prompts/TheMovieDBKernelFunctions.cs` — the main TMDb surface (genres, person search, movie search, discover with filters, movie details, trailers/videos).
 - `Prompts/DateTimeKernelFunctions.cs` — relative-date helpers so the model can resolve "in the last 10 years" into ISO date ranges rather than hallucinating them. Static methods.
@@ -91,7 +125,9 @@ The class names still end in `KernelFunctions` for continuity with the file hist
 
 ### Persistence
 
-`ChatSessionRepository.cs` — Cosmos DB, database `database`, container `chat-sessions`, hardcoded. Document id doubles as the partition key; ids come from `GenId()` (base64 of 5 random bytes, regenerated until URL-safe-clean). The conversation is a `List<Microsoft.Extensions.AI.ChatMessage>` serialized straight into the document via `CosmosSystemTextJsonSerializer`.
+`ChatSessionRepository.cs` — Cosmos DB, database `database`, container `chat-sessions`, hardcoded. Document id doubles as the partition key; ids come from `GenId()` (base64 of 5 random bytes, regenerated until URL-safe-clean). The conversation is a `List<Microsoft.Extensions.AI.ChatMessage>` serialized straight into the document via `CosmosSystemTextJsonSerializer`, alongside `HydratedMovies` (see hydration tiers above).
+
+The ask routes mutate the document they loaded and call `SaveChatSession`. The old `UpdateChatSession(id, ...)` overloads did a `ReadItemAsync` first, so saving one turn cost two Cosmos round trips; they are gone.
 
 Two constraints on that serializer, both load-bearing:
 
@@ -159,4 +195,6 @@ A missing `OpenMovieDb:Api-Key` fails at DI resolution of `OpenMovieDbAgent`, wh
 
 ### Observability
 
-OpenTelemetry traces export to Azure Monitor. Every function and repository method opens a span named `movie-tracker-func.*` via the injected `Tracer`; keep that convention when adding operations. Model spans come from `.UseOpenTelemetry(loggerFactory, serviceName, o => o.EnableSensitiveData = true)` on the `IChatClient`, which replaced the `Microsoft.SemanticKernel.Experimental.GenAI.EnableOTelDiagnosticsSensitive` AppContext switch — prompts and completions still appear in traces. The activity source is `serviceName` itself, so it is covered by the existing `AddSource(serviceName)`; `Microsoft.Extensions.AI*` and `Microsoft.Agents.AI*` are registered alongside it for the `execute_tool` spans.
+OpenTelemetry traces export to Azure Monitor. Every function and repository method opens a span named `movie-tracker-func.*` via the injected `Tracer`; keep that convention when adding operations.
+
+`LogUsage` logs `input / cachedInput / output / reasoning / total` off `AgentResponse.Usage` each turn, and `RunTurnAsync` logs how many stored messages compaction actually sent. Azure Monitor's token metrics on the Cognitive Services account report 0 and the `gen_ai.usage` spans arrive only partially, so these logs are the usable measurement. **`cachedInput` is the one to watch:** non-zero means the static system prompt, tool schemas and JSON schema are hitting Azure OpenAI's automatic prompt cache; a persistent zero means something started varying that prefix and the discount is being lost. Note prompt caching lowers cost but **not** TPM — quota is estimated before the cache lookup — so only compaction relieves the 200K TPM ceiling. These are worker logs and do not appear in `func start` console output; read them in App Insights. Model spans come from `.UseOpenTelemetry(loggerFactory, serviceName, o => o.EnableSensitiveData = true)` on the `IChatClient`, which replaced the `Microsoft.SemanticKernel.Experimental.GenAI.EnableOTelDiagnosticsSensitive` AppContext switch — prompts and completions still appear in traces. The activity source is `serviceName` itself, so it is covered by the existing `AddSource(serviceName)`; `Microsoft.Extensions.AI*` and `Microsoft.Agents.AI*` are registered alongside it for the `execute_tool` spans.

--- a/guide.md
+++ b/guide.md
@@ -1,0 +1,208 @@
+# Optimizing a .NET Microsoft Agent Framework App (Microsoft.Agents.AI 1.15.0): Implementation Guide
+
+## TL;DR
+- **The single biggest misconception to kill first: none of the "conversation state" mechanisms (`AgentSession`, `ChatHistoryProvider`, `ChatOptions.ConversationId`, or the Responses API's server-side state) reduce *billed input tokens* on their own — every one of them still puts the full prior conversation into the model's input window on each turn.** OpenAI's own "Migrate to the Responses API" guide is explicit: "Even when using previous_response_id, all previous input tokens for responses in the chain are billed as input tokens in the API." Only two levers actually cut billed input tokens: **(a) trimming/summarizing** history, and **(b) automatic prompt caching**, which *discounts* (does not remove) the constant prefix. Caching cuts *cost*, not *TPM* — so it does nothing for your 200K DataZoneStandard throttling ceiling; only trimming does.
+- Your fastest, lowest-risk wins are app-side and never touch the framework: **(1)** run the funny-fact pre-call **concurrently** with the main agent call (`Task.WhenAll`, not Workflows) to remove ~2 LLM round trips from the critical path; **(2)** stop re-hydrating the entire TMDb history every turn by **caching the hydrated view-model per message** in Cosmos; **(3)** make the prompt **cache-friendly** (static system prompt + 27 tool schemas + JSON schema first, byte-identical) and add a **rolling-window + summary reducer** to bound token growth.
+- **Verified rename that bit the prior guide:** 1.15.0 ships `AgentResponse`/`AgentResponseUpdate` and `AgentSession` (the old `AgentRunResponse`/`AgentThread` names were renamed); the `RunAsync` parameter is now `session:`, not `thread:`. The auto-generated `/dotnet/api` pages still show the old names — treat them as stale. Streaming over SSE is **incoherent with your strict-JSON + full-hydration contract** and not worth adopting; A2A/AG-UI/OpenAI-compatible hosting adapters and the Durable extension are all poor fits here.
+
+## Key Findings
+
+### The token-efficiency question, answered precisely (Question A1)
+For each state mechanism, the crucial question is whether it reduces *billed input tokens* or merely client-side payload:
+
+| Mechanism | Verified in 1.15.0? | Reduces billed input tokens? | What it actually does |
+|---|---|---|---|
+| `AgentSession` + `SerializeSessionAsync`/`DeserializeSessionAsync` | **Yes** (namespace `Microsoft.Agents.AI`; renamed from `AgentThread`) | **No** | Persists conversation state (incl. full history) across requests/restarts. Full history is still replayed into the model input. Moves *where* state lives, not what's billed. |
+| `ChatClientAgentOptions.ChatHistoryProvider` | **Yes** (property + `ChatHistoryProviderFactory`; `CosmosChatHistoryProvider` ships in `Microsoft.Agents.AI.CosmosNoSql`, **preview**) | **No** (by itself) | Framework loads history before each call and persists after. Same replay. **But** it's the correct hook to attach a *reducer* (trimming/summarization), which is what reduces tokens. |
+| `AIContextProvider` | **Yes** (base class in `Microsoft.Agents.AI`) | **Depends** | Injects/overrides context messages, tools, instructions before invocation. Can *reduce* tokens if you use it to inject a compact summary instead of raw history — or *increase* them (RAG/memory). |
+| `ChatOptions.ConversationId` | **Yes** (used for service-managed history) | **No** | Signals that the *service* holds history (Responses API / Foundry). The service still injects all prior turns into the input window. |
+| Responses API (`OpenAIResponseClientExtensions.AsAIAgent`, `previous_response_id`) | **Yes** (extension confirmed in `Microsoft.Agents.AI.OpenAI`) | **No** | Server-side conversation state removes history from *your request payload*, but per OpenAI's migration guide "all previous input tokens for responses in the chain are billed as input tokens." Savings come only from prompt caching of the now-identical prefix. |
+
+**Bottom line for A1:** switching state mechanisms is a *code-hygiene and payload* change, not a token-cost change. If you want fewer billed tokens you must trim/summarize; if you want cheaper billed tokens you must make the prefix cacheable. (A Microsoft Q&A thread on `previous_response_id` confirms the mechanism: Azure "reconstitutes the full conversation context server-side and injects all prior turns into the model's input window… counted as input tokens on every follow-up request," with savings arising only because the identical prefix "is very likely to qualify for automatic prompt caching.")
+
+### Prompt caching on Azure OpenAI (Question A2)
+- **Eligibility:** automatic, no code change, for prompts ≥ **1,024 tokens**; the **first 1,024 tokens must be byte-identical** across requests; matching then extends in 128-token increments. Per Microsoft Learn's "Prompt caching with Azure OpenAI in Microsoft Foundry Models": "After the first 1,024 tokens, cache hits occur for every 128 additional identical tokens. A single character difference in the first 1,024 tokens results in a cache miss, which is characterized by a cached_tokens value of 0." Routing uses a hash of roughly the first 256 tokens.
+- **What's cacheable:** the structured-output JSON schema acts as a prefix to the system message and is cacheable; the tools array and the messages array both count toward the 1,024-token minimum and are cacheable. Your large static system prompt + 27 tool schemas + strict JSON schema is an ideal, large constant prefix.
+- **Discount:** per Redress Compliance's 2026 Azure OpenAI pricing analysis, "Cached input prices at 10 percent of the input rate on the GPT-5 tiers… a 90 percent discount. GPT-4.1 and o4-mini cache at 25 percent of input… The 50 percent figure still in circulation is the GPT-4o number." Confirm the exact rate for `gpt-5.4-mini` on the Azure pricing page — this model name is newer than most indexed sources, so generalize from the GPT-5 family and verify. Microsoft Learn: "cache reads are billed at a discount on input token pricing for Standard deployment types and up to 100% discount on input tokens for Provisioned deployment types."
+- **What breaks caching:** anything that changes the prefix — appending tool-call/tool-result messages *at the front*, reordering tools, injecting a per-request timestamp or session id near the top, or changing the JSON schema. Appending new turns at the *end* is fine and preserves the cached prefix; that is exactly the shape you want.
+- **TTL:** the two sources disagree and both matter. OpenAI's own "Prompt Caching in the API" states caches "are typically cleared after 5-10 minutes of inactivity and are always removed within one hour of the cache's last use." Microsoft's Azure Foundry docs state caches are cleared within **24 hours**. Treat the practical eviction window as *minutes of inactivity* for a low-traffic chat app; don't count on long-lived cache survival between infrequent turns. In-memory caching is compatible with all data-residency regions; extended caching temporarily stores KV tensors on GPU machines (a residency consideration — see Caveats).
+- **⚠️ Critical for your 200K TPM DataZoneStandard deployment:** **cached tokens still count against TPM.** Per Microsoft Learn's quota docs, "TPM rate limits are based on the maximum number of tokens that are estimated to be processed by a request at the time the request is received. It isn't the same as the token count used for billing, which is computed after all processing is completed." The estimate is computed from the prompt + `max_tokens` *before* any cache lookup, so prompt caching lowers your bill but gives you **zero additional TPM headroom**. Only trimming/summarizing reduces TPM pressure. On gpt-5.6+ Microsoft now bills cache *writes* in addition to discounted reads ("Models before gpt-5.6 don't charge extra to write to the cache. On gpt-5.6 and later models, cache writes are billed in addition to discounted cache reads"); for `gpt-5.4-mini` (pre-5.6) cache writes are almost certainly free, but verify.
+
+### Trimming/summarization that preserves follow-ups (Question A3)
+The framework ships an `InMemoryChatHistoryProvider` that accepts a reducer, e.g. `MessageCountingChatReducer(20)`, configured via `InMemoryChatHistoryProviderOptions { ChatReducer = ... }`. A naive count/token trim will break "which of those had the highest rating?" because that follow-up depends on the *entities* from the prior turn, not the prose. The robust pattern: keep the last N raw turns **plus** a rolling structured summary that always carries forward the last movie-list result (ids + names + any ratings already fetched). Inject that summary via an `AIContextProvider` so it's always present regardless of how aggressively raw turns are trimmed. Note the open question raised in repo discussion #4443: persisting a *session* alone grows unbounded because it holds the entire history and "there doesn't seem to be a built-in way to reduce or trim the history within the session" — so pair a persistent provider with an explicit reducer rather than relying on session serialization to stay small.
+
+### Stop re-hydrating the entire history (Question A4)
+This is pure app-side and one of the best value/risk items. Today every movie id in every past assistant message is re-fetched from TMDb on every call (memory-cached per instance, so it's cold on every new Functions instance and grows O(conversation length)). Fix: **persist the hydrated `movieList` view-model alongside each assistant message in Cosmos** when you first build it. On subsequent turns, read the stored view-model back rather than re-walking TMDb. You still return the full message list the contract requires, but hydration cost becomes O(new turn) instead of O(history). This also removes a per-instance memory cache that doesn't survive scale-out.
+
+### 27 flat tools (Question B5)
+A single flat list of 27 tools sent on every call hurts two ways: selection accuracy (more near-duplicate schemas to disambiguate) and cost/cache pressure (larger tool array — though as a *constant* prefix it caches well). Options, best first for your app:
+- **Prune/consolidate.** Ten date helpers is a strong smell — most date math should be done in C#, not exposed as LLM tools. Collapsing the 7–10 date/planner helpers into 1–2 higher-level tools is the highest-leverage change and keeps everything in one agent.
+- **Agents-as-tools (`AIAgent.AsAIFunction()`).** Confirmed: extension method in namespace `Microsoft.Agents.AI` (class `AIAgentExtensions`, source `dotnet/src/Microsoft.Agents.AI/AgentExtensions.cs`), returns a `Microsoft.Extensions.AI.AIFunction`; the inner agent's Name/Description become the tool name/description and it runs its own tool-calling loop internally via `agent.RunAsync`. Good for grouping (e.g., a "RatingsAgent" that owns the ratings/trailer tools) so the top agent sees a few coarse tools. Cost: each delegated call is a nested LLM round trip — more latency and more total tokens, so only worth it if pruning alone can't get tool count down. (Exact optional-parameter list not fully confirmed against source; the confirmed minimum form is `agent.AsAIFunction()`.)
+- **Handoff/group-chat orchestration** (`AgentWorkflowBuilder.BuildHandoff`/handoff patterns): overkill for a single-domain movie Q&A — see "Don't bother."
+
+### Concurrent funny-fact (Question B6)
+The funny-fact currently runs **serially before** the main call: LLM #1 (entity detection) → Wikipedia/Wikidata fetch → LLM #2 (write fact), then the main agent call. Those ~2 extra round trips sit on the critical path for no reason — the funny fact is independent of the main answer. Run them concurrently with `Task.WhenAll`. **What do Workflows (`BuildConcurrent`) buy over `Task.WhenAll`? Nothing here — be blunt.** `AgentWorkflowBuilder.BuildConcurrent(IEnumerable<AIAgent> agents, Func<IList<List<ChatMessage>>, List<ChatMessage>>? aggregator)` fans one input out to multiple agents and aggregates; it adds a superstep runtime, event streaming (`AgentResponseUpdateEvent`), and checkpointing you don't need for two independent tasks inside a single request/response Function. Its aggregator signature also fights your two-different-shapes output (a fact string + a structured movie list). Use plain `Task.WhenAll`. **⚠️ TPM note:** firing both LLM calls simultaneously makes your token usage bursty — two concurrent calls against the 200K TPM ceiling with per-second/RPM quantization (RPM is set proportionally to TPM) raises 429 risk under load; add retry-with-jitter (see B7).
+
+### Middleware for retries / tool-call validation / anti-hallucination (Question B7)
+Confirmed surface in 1.15.0:
+- `agent.AsBuilder().Use(...).Build()` returns a **new** agent — you must assign it or the middleware never runs.
+- **Function-calling middleware** signature: `async ValueTask<object?> Mw(AIAgent agent, FunctionInvocationContext context, Func<FunctionInvocationContext, CancellationToken, ValueTask<object?>> next, CancellationToken ct)`. `FunctionInvocationContext` exposes `Function.Name` and `Arguments`, is scoped to a single tool call, and wraps each call independently within a turn. This is the correct home for your hand-rolled defenses: validate/sanitize tool arguments before execution, cap tool-call counts per turn, and **guard against model-invented IDs** by validating ids against TMDb before the call proceeds (short-circuit by returning an error result instead of calling `next`). It only fires for `FunctionInvokingChatClient`-based tools (your local functions qualify; hosted/OpenAPI tools may not — a known gap per repo issue #2960).
+- Retries belong in **IChatClient middleware** (`AsBuilder().UseFunctionInvocation(...)` / a retry decorator) or via `FunctionInvokingChatClient` `IncludeDetailedErrors`, so transient 429s from the DataZoneStandard cap get retried with backoff.
+
+### A better client API — streaming, delta route, hosting adapters (Questions C8–C10)
+- **Streaming (`RunStreamingAsync` → `IAsyncEnumerable<AgentResponseUpdate>`): incoherent with your current contract.** Your response is a *strict JSON structured output* (`MovieList[]`, `FunnyFact`) that must be fully materialized before the hydration step can attach `movieList` view-models. The framework's own structured-output guidance for streaming confirms this shape: you collect all updates and call `ToAgentResponseAsync()` / `Deserialize<T>()` at the *end* — i.e., you don't get usable partial structured output mid-stream. You also can't hydrate a half-emitted movie list. Additionally, Azure Functions isolated worker **cannot stream** with the default `HttpRequestData` model (per Microsoft Learn, "If you use HttpRequestData, the body of the HTTP request can't be a stream… consider using the ASP.NET Core integration model instead"), and per Microsoft Learn "230 seconds is the maximum amount of time that an HTTP triggered function can take to respond to a request… because of the default idle timeout of Azure Load Balancer." SSE is a poor fit for Functions generally. Streaming is only coherent for a plain-text side-channel (e.g., streaming the funny-fact text), which is marginal. **Don't stream the structured payload.**
+- **Delta-only v2 route: worth it, additive.** Returning only the latest turn instead of replaying the full hydrated transcript is a real win for payload and for the re-hydration problem. Add `POST /api/chat/{chatId}/ask/v2` returning `{ funnyFact, turn: { role, text, movieList? } }` (just the new assistant turn, hydrated once). Keep the existing route returning the full transcript for the existing frontend. This pairs naturally with the hydration-cache fix.
+- **Hosting adapters (A2A, OpenAI-compatible, AG-UI) and the Durable extension: poor fit — say so plainly.** You have a fixed HTTP contract and a specific frontend. A2A exposes your agent to *other agents* (`Microsoft.Agents.AI.Hosting.A2A.AspNetCore`); OpenAI-compatible endpoints let *generic OpenAI SDK clients* call it (`/v1/chat/completions`, `/v1/responses`); AG-UI is for a generic agent-UI protocol. None has a consumer in your system, and all are net-new surface (several still preview, e.g. AG-UI hosting at `1.0.0-preview…`). The Durable Azure Functions extension targets long-running/multi-hour orchestrations needing checkpointing and exactly-once semantics — your calls are 5–10s, far under the 230s limit. Adopting it adds a storage backend and complexity for zero benefit.
+
+## Ranked recommendations — (est. token/latency saving) ÷ (implementation risk)
+
+| # | Recommendation | Est. saving | Risk | Breaks contract? | Notes |
+|---|---|---|---|---|---|
+| 1 | **Concurrent funny-fact** (`Task.WhenAll`, remove ~2 LLM round trips from critical path) | High latency (likely the largest single latency cut) | Low | No | Watch bursty TPM/RPM; add retry |
+| 2 | **Cache hydrated `movieList` per message in Cosmos** (hydration O(new turn) not O(history)) | High latency + TMDb/RU | Low | No | Pure app-side |
+| 3 | **Cache-friendly prompt ordering** (static system prompt + tools + JSON schema first, byte-identical) | High cost (~90% off the constant prefix on GPT-5 tiers) | Low | No | No TPM relief |
+| 4 | **Rolling-window + summary reducer** via `ChatHistoryProvider`/`AIContextProvider` | High cost **and** TPM | Medium | No (internal) | Must preserve follow-up entities |
+| 5 | **Prune/consolidate the 27 tools** (esp. the date helpers) | Medium cost + accuracy | Low–Med | No | Do C#-side date math |
+| 6 | **Function-calling middleware** for id validation + retries | Quality + resilience | Low–Med | No | Replaces hand-rolled defenses |
+| 7 | **Additive `/ask/v2` delta route** | Medium payload | Medium | No (additive) | New route only |
+| 8 | **Move to Responses API for server-side state** | Payload only; cost only via caching | High | No (internal) | Preview/residency risk; **no billed-token or TPM reduction** |
+
+## Concrete C# for the top 3
+
+> API names below verified against the shipped 1.15.0 surface (`AgentResponse`, `AgentSession`, `session:` parameter, `AsBuilder().Use`, `FunctionInvocationContext`, `RunStreamingAsync`). Where a member could not be fully confirmed it is flagged inline.
+
+### 1. Run the funny-fact concurrently with the main agent call
+```csharp
+// BEFORE: funnyFact computed serially (2 LLM round trips) THEN agent.RunAsync.
+// AFTER: both run concurrently. Note the response type is AgentResponse (NOT AgentRunResponse) in 1.15.0.
+
+public async Task<ChatAskResult> AskAsync(
+    string chatId,
+    IList<ChatMessage> history,          // Microsoft.Extensions.AI.ChatMessage
+    string userText,
+    CancellationToken ct)
+{
+    var messages = new List<ChatMessage>(history) { new(ChatRole.User, userText) };
+
+    // Kick off the independent funny-fact pipeline (LLM -> wiki/wikidata -> LLM) without awaiting.
+    Task<string> funnyFactTask = _chatPlanner.GenerateEnhancedFunnyFactAsync(userText, ct);
+
+    // Main agent call runs at the same time.
+    Task<AgentResponse> answerTask = _agent.RunAsync(messages, session: _session, cancellationToken: ct);
+
+    await Task.WhenAll(funnyFactTask, answerTask).ConfigureAwait(false);
+
+    AgentResponse answer = await answerTask;      // .Text, .Messages available
+    string funnyFact      = await funnyFactTask;
+
+    // ...deserialize structured output, hydrate, persist as today...
+    return BuildResult(funnyFact, answer);
+}
+```
+Do **not** wrap this in `AgentWorkflowBuilder.BuildConcurrent` — it adds a superstep/checkpointing runtime with no payoff for two independent tasks, and its aggregator shape doesn't match your two different output types.
+
+### 2. Cache the hydrated movie view-model instead of re-walking TMDb every turn
+```csharp
+// Persist the hydrated view-model with each assistant message so future turns
+// return the full contract-required list WITHOUT re-fetching all of history from TMDb.
+
+public sealed record StoredAssistantTurn(
+    string Role,
+    string Text,
+    IReadOnlyList<MovieViewModel>? MovieList);   // hydrated ONCE, then stored
+
+// When producing a new assistant turn:
+var hydrated = await _tmdb.HydrateAsync(newMovieIds, ct);   // only the NEW ids
+var turn = new StoredAssistantTurn("assistant", answer.Text, hydrated);
+await _cosmos.AppendTurnAsync(chatId, turn, ct);
+
+// When building the contract response, read stored view-models back — no TMDb fan-out:
+IReadOnlyList<StoredAssistantTurn> transcript = await _cosmos.LoadTranscriptAsync(chatId, ct);
+var messages = transcript.Select(t => new ClientMessage(t.Role, t.Text, t.MovieList)).ToList();
+// hydration cost is now O(new turn), not O(entire history)
+```
+Optionally add a TMDb-fact TTL if movie metadata can change; a per-instance `IDistributedMemoryCache` is fine as an L1 in front of Cosmos but does not survive scale-out (that's why the source of truth should be Cosmos).
+
+### 3. Cache-friendly prefix + history reducer + id-validation middleware
+```csharp
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+
+// (a) Keep the large STATIC content first and byte-identical: instructions + tools + JSON schema.
+//     Put anything per-request (timestamps, chatId) at the END so it never disturbs the cached prefix.
+var options = new ChatClientAgentOptions
+{
+    Name = "MovieAgent",
+    ChatOptions = new ChatOptions
+    {
+        Instructions   = StaticSystemPrompt,                    // unchanged across requests
+        Tools          = _tools,                                // stable order => stable prefix
+        ResponseFormat = ChatResponseFormat.ForJsonSchema<MovieAnswer>() // schema is part of the cacheable prefix
+    },
+    // (b) Bound token growth. InMemory provider + a reducer; pair with a summary context provider
+    //     so follow-ups ("which of those had the highest rating?") keep the prior movie-list entities.
+    ChatHistoryProvider = new InMemoryChatHistoryProvider(
+        new InMemoryChatHistoryProviderOptions { ChatReducer = new MessageCountingChatReducer(20) }),
+    AIContextProviders = [ new RollingMovieSummaryProvider() ]  // injects last movie-list ids+names+ratings
+};
+
+AIAgent baseAgent = _chatClient.AsAIAgent(options);   // .AsAIAgent extension, Microsoft.Agents.AI(.OpenAI)
+
+// (c) Function-calling middleware: reject model-invented TMDb ids before the tool runs.
+async ValueTask<object?> ValidateIds(
+    AIAgent agent,
+    FunctionInvocationContext context,
+    Func<FunctionInvocationContext, CancellationToken, ValueTask<object?>> next,
+    CancellationToken ct)
+{
+    if (context.Function.Name is "GetMovieById" or "GetRating"
+        && context.Arguments.TryGetValue("movieId", out var raw)
+        && !await _tmdb.ExistsAsync(Convert.ToInt32(raw), ct))
+    {
+        // short-circuit: do NOT call next(); hand the model a correctable error
+        return $"Error: movieId {raw} does not exist. Do not invent ids; call a search tool first.";
+    }
+    return await next(context, ct);
+}
+
+AIAgent agent = baseAgent
+    .AsBuilder()
+    .Use(ValidateIds)          // function-calling middleware; assign the returned agent!
+    .Build();
+```
+> Verification flags: `InMemoryChatHistoryProvider`, `InMemoryChatHistoryProviderOptions.ChatReducer`, and `MessageCountingChatReducer` appear in official 1.x docs but confirm the exact constructor/property names against the `Microsoft.Agents.AI` assembly you have restored; `CosmosChatHistoryProvider` (if you prefer Cosmos-backed history over your existing manual Cosmos persistence) is in `Microsoft.Agents.AI.CosmosNoSql` and is **preview**. `ChatResponseFormat.ForJsonSchema<T>()` is the MEAI structured-output helper; you may keep your existing `AIJsonSchemaTransformOptions { DisallowAdditionalProperties, RequireAllProperties }` schema instead.
+
+## Don't bother (features that look applicable but aren't)
+- **Workflows `BuildConcurrent` for the funny-fact.** Plain `Task.WhenAll` does the same fan-out with none of the superstep/checkpoint/event-stream machinery, and the `BuildConcurrent` aggregator (`Func<IList<List<ChatMessage>>, List<ChatMessage>>`) doesn't fit your two-different-output-shapes case. Zero benefit here.
+- **Multi-agent handoff / group-chat orchestration.** Designed for multi-domain routing (sales/support/billing). Your app is single-domain movie Q&A; a handoff router just adds an extra routing LLM call and latency.
+- **A2A, OpenAI-compatible, and AG-UI hosting adapters.** No consumer in your system; you have a fixed HTTP contract and a bespoke frontend. These expose agents to *other agents* or *generic clients* you don't have. Net-new surface, several still preview.
+- **Durable Task / Durable Functions extension.** For long-running (minutes-to-hours), checkpointed, exactly-once orchestrations. Your requests are 5–10s, far under the 230s HTTP limit. Adds a storage backend and operational weight for nothing.
+- **Background responses (`AllowBackgroundResponses`, `ContinuationToken` polling).** Only relevant for long-running generations that risk the request timeout. Not your profile.
+- **Streaming SSE for the structured payload.** Incompatible with strict-JSON structured output + full hydration, and awkward on Functions isolated worker. Skip (a plain-text funny-fact stream is the only coherent variant and is marginal).
+- **Switching to the Responses API purely to "hold state server-side."** It does **not** reduce billed input tokens or TPM; it only shrinks your request payload. Adopt it only if you specifically want server-managed threads *and* you've confirmed Azure availability + `store:true` residency for your deployment — otherwise the ChatHistoryProvider path keeps you on the well-trodden Chat Completions surface you already use.
+
+## Preview / unstable / constraint flags
+- **`AgentResponse` vs `AgentRunResponse`:** 1.15.0 ships **`AgentResponse`/`AgentResponseUpdate`** (renamed per repo issue #2899; reflected in the changelog — "AgentRunResponse and AgentRunResponseUpdate were renamed to AgentResponse and AgentResponseUpdate" — and the current Learn "Running Agents" .NET page). The auto-generated `/dotnet/api` pages (e.g., `DelegatingAIAgent.RunAsync`) still show the old `AgentRunResponse`/`AgentThread` names — **stale, do not trust**. Confidence: high.
+- **`session:` parameter:** `RunAsync`'s `thread` parameter was renamed to `session:` (type `AgentSession`). Per a Microsoft community-hub migration note, "The thread parameter is now session (type AgentSession). If you were using named arguments, this is a compile error." Confidence: high.
+- **`SerializeSessionAsync`/`DeserializeSessionAsync`:** exist on `AIAgent` (serialize to/from `JsonElement`). There was an open request (repo issue #3725) to make serialize fully async because a synchronous `SerializeSession` variant existed — confirm which overload your build exposes. Confidence: medium-high.
+- **OpenAI SDK compatibility (directly relevant to your pinned stack):** repo issue #4380 documented a runtime `MissingMethodException` (`ResponsesClient.get_Model()` not found) when `AsAIAgent()` on a Responses client ran against **OpenAI SDK 2.9.0**; the issue is **closed**. Root cause (per the issue thread): "Microsoft.Extensions.AI was compiled against OpenAI version 2.8.0, while your project is directly referencing version 2.9.0… remove the explicit reference and allow the correct version to be resolved transitively." Microsoft.Agents.AI.OpenAI 1.5.0 already pins **`OpenAI (>= 2.10.0)`**, so version 1.15.0 almost certainly requires ≥ 2.10.0 — which **matches your pinned OpenAI SDK 2.10.0**, so the Responses path should load. **Do not pin an older explicit `OpenAI` reference**, or you reintroduce the mismatch. `Microsoft.Agents.AI.OpenAI` depends on the base `OpenAI` SDK (+ `Microsoft.Extensions.AI.OpenAI`), **not** on `Azure.AI.OpenAI`; no evidence of a known Azure.AI.OpenAI 2.9.0-beta.1 ↔ OpenAI 2.10.0 conflict was found. Verify the exact 1.15.0 dependency block on the NuGet page. Confidence: medium-high (exact 1.15.0 dependency block not directly fetched).
+- **`Microsoft.Agents.AI.CosmosNoSql` is preview** (versions like `1.13.0-preview…`), not GA. If you adopt `CosmosChatHistoryProvider`/`CosmosCheckpointStore`, treat as preview and pin deliberately; it also has security notes (stored history is accepted as-is → indirect prompt-injection risk if the store is compromised; use `MessageTtlSeconds` for retention).
+- **Responses API on Azure:** `previous_response_id` bills all prior tokens; the persistent **Conversations API** (server `conversation_id`) reportedly rolled out via the Foundry v1 REST API (~April 2026) but users report `404`s on some resources — treat as not-yet-reliable. `store:true` persists responses server-side; on **DataZoneStandard**, data at rest stays in your geography and processing stays within the data zone, but **extended** prompt caching temporarily stores KV tensors on GPU machines — a residency nuance to check with your compliance owner. In-memory caching is residency-safe.
+- **`gpt-5.4-mini` specifics:** the exact model name and its caching discount/cache-write behavior are newer than most indexed sources. Generalize from the GPT-5 family (~90% cached-input discount; cache writes free pre-gpt-5.6) and **verify the exact rate and cache-write policy on the Azure pricing page** before quoting a number.
+- **200K TPM DataZoneStandard:** nothing recommended here *newly constrains* the deployment, but note explicitly: **prompt caching does not reduce TPM consumption** (TPM is estimated pre-processing), and **concurrent calls (funny-fact + main) are burstier** against the ceiling — add retry-with-jitter for 429s and consider a token-bucket limiter if you approach the cap.
+
+## Recommendations (staged)
+1. **Ship this week (low risk, no contract change):** funny-fact `Task.WhenAll` (#1) + hydrated-view-model caching in Cosmos (#2). Instrument first — see benchmarking note below.
+2. **Next (cost + TPM):** cache-friendly prefix ordering (#3), then the rolling-window + summary reducer (#4). Confirm `cached_tokens > 0` in the usage response after #3; confirm mean input tokens/turn drops and stops growing with conversation length after #4.
+3. **Then (quality + resilience):** consolidate the 27 tools starting with the date helpers (#5) and add function-calling middleware for id validation + retry (#6).
+4. **Optional (additive API):** ship `/ask/v2` delta route (#7) once #2 is in place.
+5. **Only if a concrete need appears:** Responses API server-side state (#8) — and only after confirming Azure availability and residency for your deployment.
+
+**Benchmarking thresholds that would change these calls:** measure with a **same-session A/B against unchanged code** (your end-to-end latency drifts 10–15% between sessions, so cross-session comparisons are meaningless). Track: p50/p95 end-to-end latency, mean billed input tokens/turn, `cached_tokens`/`prompt_tokens` ratio, TMDb call count/turn, and 429 rate. If after #3 `cached_tokens` stays 0, your prefix isn't byte-stable — fix ordering before doing anything else. If mean input tokens/turn still grows linearly after #4, the reducer/summary isn't engaging. If the 429 rate rises after #1, add the token-bucket limiter before rolling out further concurrency.
+
+## Caveats
+- The exact 1.15.0 NuGet dependency block was inferred (from 1.5.0, which already requires `OpenAI ≥ 2.10.0`) rather than fetched directly — verify on the package page. Your pinned OpenAI 2.10.0 satisfies the constraint that fixed issue #4380.
+- Several member names in the reducer/history-provider area (`InMemoryChatHistoryProviderOptions.ChatReducer`, `MessageCountingChatReducer`) and the streaming-aggregation helper (`ToAgentResponseAsync()` vs the older `ToAgentRunResponseAsync()`) should be confirmed against your restored assembly, since docs and blogs straddle the rename boundary.
+- Prompt-cache TTL sources conflict: OpenAI's API docs say 5–10 min inactivity / removed within 1 hour, while Azure Foundry docs say within 24 hours. For a low-traffic chat app, plan for minutes-scale eviction, not hours.
+- `gpt-5.4-mini` behavior (caching discount, cache-write charges) is generalized from the GPT-5 family; confirm on the Azure pricing page.
+- All token/latency figures here are directional; the guide deliberately prescribes *what to measure* rather than promising hard percentages, given the 10–15% inter-session drift.

--- a/src/MovieTracker.Backend/ChatSessionRepository.cs
+++ b/src/MovieTracker.Backend/ChatSessionRepository.cs
@@ -8,6 +8,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
+using MovieTracker.Backend.Functions;
 using ChatMessage = Microsoft.Extensions.AI.ChatMessage;
 
 namespace MovieTracker.Backend
@@ -24,6 +25,14 @@ namespace MovieTracker.Backend
         // created before this migration cannot be loaded.
         public List<ChatMessage> ChatHistory { get; set; }
         public string? FunnyFact { get; set; }
+
+        // Every movie this session has ever shown, already hydrated from TMDb, keyed by TMDb id.
+        // Chat-Ask replays the whole transcript back to the frontend on every call, so without this
+        // it re-fetched details + videos for every movie in every past turn - two TMDb round trips
+        // per movie, growing with conversation length. The IDistributedCache in front of it is
+        // AddDistributedMemoryCache, so it is per-instance and cold after every scale-out or restart;
+        // this is the copy that actually survives. Bounded by HydratedMovieLimit in Chat-Ask.
+        public Dictionary<string, MovieViewModel>? HydratedMovies { get; set; }
     }
 
     public class ChatSessionRepository(CosmosClient cosmosClient, ILogger<ChatSessionRepository> logger, Tracer tracer)
@@ -83,45 +92,9 @@ namespace MovieTracker.Backend
             }
         }
 
-        public async Task<MoviceTrackerChatSession> UpdateChatSession(string id, List<ChatMessage> chatHistory)
-        {
-            using var activity = tracer.StartActiveSpan("movie-tracker-func.chat-session-repository.update-chat-session");
-            try
-            {
-                var response = await chatHistoryContainer.ReadItemAsync<MoviceTrackerChatSession>(id, new PartitionKey(id));
-                MoviceTrackerChatSession movieChatSession = response.Resource;
-                movieChatSession.ChatHistory = chatHistory;
-                var updateResponse = await chatHistoryContainer.ReplaceItemAsync(movieChatSession, id, new PartitionKey(id));
-                return movieChatSession;
-            }
-            catch (Exception ex)
-            {
-                logger.LogCritical("{@ex}", ex);
-                throw;
-            }
-        }
-
-        public async Task<MoviceTrackerChatSession> UpdateChatSession(string id, List<ChatMessage> chatHistory, string? funnyFact)
-        {
-            using var activity = tracer.StartActiveSpan("movie-tracker-func.chat-session-repository.update-chat-session-with-funny-fact");
-            try
-            {
-                var response = await chatHistoryContainer.ReadItemAsync<MoviceTrackerChatSession>(id, new PartitionKey(id));
-                MoviceTrackerChatSession movieChatSession = response.Resource;
-                movieChatSession.ChatHistory = chatHistory;
-
-                movieChatSession.FunnyFact = funnyFact;
-
-                var updateResponse = await chatHistoryContainer.ReplaceItemAsync(movieChatSession, id, new PartitionKey(id));
-                return movieChatSession;
-            }
-            catch (Exception ex)
-            {
-                logger.LogCritical("{@ex}", ex);
-                throw;
-            }
-        }
-
+        // Chat-Ask already holds the document it loaded at the top of the request, so it writes the
+        // mutated instance straight back. The UpdateChatSession(id, ...) overloads this replaced did a
+        // ReadItemAsync first, which meant two Cosmos round trips per /ask to save one turn.
         public async Task<MoviceTrackerChatSession> SaveChatSession(MoviceTrackerChatSession movieChatSession)
         {
             using var activity = tracer.StartActiveSpan("movie-tracker-func.chat-session-repository.save-chat-session");

--- a/src/MovieTracker.Backend/Functions/Function.cs
+++ b/src/MovieTracker.Backend/Functions/Function.cs
@@ -3,8 +3,10 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 using Microsoft.Agents.AI;
+using Microsoft.Agents.AI.Compaction;
 using Microsoft.Extensions.AI;
 using OpenTelemetry.Trace;
+using System.Collections.Concurrent;
 using System.Text.Json.Serialization;
 using System.Text.Json;
 using Microsoft.Extensions.Caching.Distributed;
@@ -111,6 +113,11 @@ namespace MovieTracker.Backend.Functions
 
     public record ChatMessageResponse(string? FunnyFact, List<ChatMessage> Messages);
 
+    // Returned by Chat-Ask-V2 only. The v1 shape replays the entire hydrated transcript on every
+    // turn, so its payload and its hydration cost both grow with conversation length even though the
+    // caller already has every earlier turn. This carries just the turn that was produced.
+    public record ChatTurnResponse(string? FunnyFact, ChatMessage Turn);
+
     public class ChatSession
     {
         public string Id { get; set; }
@@ -180,6 +187,80 @@ namespace MovieTracker.Backend.Functions
         // outright. Leave the setting unset, empty, or "default" to omit it from the request.
         private readonly string? reasoningEffort = configuration["AzureOpenAi:Reasoning-Effort"];
 
+        // What is STORED and what is SENT are deliberately different. Cosmos keeps every message
+        // forever because the /ask contract replays the whole transcript back to the frontend; the
+        // model only ever sees this compacted view.
+        //
+        // Tool results dominate the token count - one DiscoverMovies call returns twenty full movie
+        // records - and they are dead weight once the assistant has written its answer, because the
+        // ids and titles a follow-up needs ("which of those had the highest rating?") are already in
+        // that answer's JSON. ToolResultCompactionStrategy collapses each old assistant-call +
+        // tool-result group into a single line recording what was called, and leaves user messages
+        // and assistant answers untouched. SlidingWindow is the backstop for genuinely long chats.
+        //
+        // Compaction always runs over the full stored history, never over its own output, so it never
+        // compounds: turn 20 sees exactly the same reduction of turns 1-10 that turn 11 saw.
+        private const int MaxModelTurns = 12;
+
+        // MAAI001 gates the whole Microsoft.Agents.AI.Compaction namespace as evaluation-only, the same
+        // way OPENAI001 gates ReasoningEffortLevel below. It is the one preview API this project takes a
+        // dependency on; the fallback if it changes shape is a hand-rolled filter over the same message
+        // list, since nothing outside RunTurnAsync can observe how the context was reduced.
+        // How much of an old tool result to keep when its group is collapsed. Enough to show the shape
+        // of what came back, not enough to pay for it twice.
+        private const int CollapsedToolResultChars = 160;
+
+        // AsChatReducer is the supported way to drive a CompactionStrategy over a plain message list -
+        // CompactionMessageIndex, which the strategies actually operate on, is not public. Each
+        // ReduceAsync builds its own index from the messages handed in and returns the included ones.
+#pragma warning disable MAAI001
+        private static readonly IChatReducer ContextReducer = new PipelineCompactionStrategy(
+        [
+            new ToolResultCompactionStrategy(
+                trigger: CompactionTriggers.HasToolCalls(),
+                // The current turn's own tool traffic stays verbatim - the model is still reasoning
+                // over it - and only earlier turns collapse.
+                minimumPreservedGroups: 2)
+            {
+                ToolCallFormatter = SummariseToolCalls,
+            },
+            new SlidingWindowCompactionStrategy(
+                trigger: CompactionTriggers.TurnsExceed(MaxModelTurns),
+                minimumPreservedTurns: 4),
+        ]).AsChatReducer();
+
+        // The built-in formatter inlines every tool result verbatim. That is sensible for a result like
+        // "Sunny and 72F" and close to useless here, where one DiscoverMovies call returns a twenty-movie
+        // JSON array: measured on a synthetic six-turn conversation the default saved 3% of the context,
+        // and this saves 68%. What a later turn needs from an old lookup is that it happened and roughly
+        // what came back - the ids and titles that mattered are already in the assistant's own answer,
+        // which this never touches.
+        private static string SummariseToolCalls(CompactionMessageGroup group)
+        {
+            var results = new Dictionary<string, string>();
+            foreach (var result in group.Messages.SelectMany(message => message.Contents).OfType<FunctionResultContent>())
+            {
+                results[result.CallId] = result.Result?.ToString() ?? string.Empty;
+            }
+
+            var lines = new List<string> { "[Earlier tool calls]" };
+            foreach (var call in group.Messages.SelectMany(message => message.Contents).OfType<FunctionCallContent>())
+            {
+                var text = results.TryGetValue(call.CallId, out var result) ? result : string.Empty;
+
+                lines.Add(text.Length <= CollapsedToolResultChars
+                    ? $"{call.Name}: {text}"
+                    : $"{call.Name}: {text[..CollapsedToolResultChars]}... [{text.Length - CollapsedToolResultChars} more chars elided]");
+            }
+
+            return string.Join("\n", lines);
+        }
+#pragma warning restore MAAI001
+
+        // The per-session hydrated-movie map rides along in the Cosmos document, so it is bounded to
+        // keep the document well clear of the 2 MB item limit. A MovieViewModel is ~1-2 KB once the
+        // overview and trailer metadata are in it.
+        private const int HydratedMovieLimit = 150;
 
         [Function("Chat-Start")]
         public async Task<IActionResult> Start([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "chat/start")] HttpRequest req)
@@ -207,7 +288,17 @@ namespace MovieTracker.Backend.Functions
                     - Populate MovieList with every relevant movie you found. Return an empty MovieList only
                       when the functions genuinely came back with no matches.
 
-                    **If the user requests a trailer, preview, teaser, promo, or attraction video, always include the trailer's YouTube link in your response, embedded in-line and wrapped in [TRAILER]...[/TRAILER] tags.**  
+                    **Ratings - IMDb is the default:**
+                    - When the user asks about a "rating", "score", or which film was "highest rated"
+                      without naming a source, they mean the IMDb rating. Call GetMovieRating for one
+                      film, or CompareMovieRatings for several, and answer from what it returns.
+                    - TMDb search and detail results carry a TmdbVoteAverage. That is not the rating.
+                      Never answer a rating question from it, and never present it as "the rating".
+                    - Rotten Tomatoes and Metacritic are secondary context; name the source if you cite them.
+                    - Report what a function returned in your own words. Never paste raw JSON from a
+                      function result into SystemMessage - the user sees that text verbatim.
+
+                    **If the user requests a trailer, preview, teaser, promo, or attraction video, always include the trailer's YouTube link in your response, embedded in-line and wrapped in [TRAILER]...[/TRAILER] tags.**
                     For example: [TRAILER]https://www.youtube.com/watch?v=vc7_mH2PWHs[/TRAILER]
 
                     Your response must always be a JSON object with these properties:
@@ -258,11 +349,15 @@ namespace MovieTracker.Backend.Functions
 
         // These run under Task.WhenAll, so one unresolvable movie would otherwise fail the
         // entire response. Hydration of a single entry is best-effort.
-        private async Task SafeProcessMovieAsync(JsonElement movie, List<MovieViewModel> movieItems, TMDbClient client)
+        private async Task SafeProcessMovieAsync(
+            JsonElement movie,
+            List<MovieViewModel> movieItems,
+            TMDbClient client,
+            ConcurrentDictionary<string, MovieViewModel> sessionCache)
         {
             try
             {
-                await ProcessMovieAsync(movie, movieItems, client);
+                await ProcessMovieAsync(movie, movieItems, client, sessionCache);
             }
             catch (Exception ex)
             {
@@ -270,7 +365,11 @@ namespace MovieTracker.Backend.Functions
             }
         }
 
-        private async Task ProcessMovieAsync(JsonElement movie, List<MovieViewModel> movieItems, TMDbClient client)
+        private async Task ProcessMovieAsync(
+            JsonElement movie,
+            List<MovieViewModel> movieItems,
+            TMDbClient client,
+            ConcurrentDictionary<string, MovieViewModel> sessionCache)
         {
             if (!movie.TryGetProperty("MovieId", out var movieIdElement))
             {
@@ -290,12 +389,27 @@ namespace MovieTracker.Backend.Functions
                 return;
             }
 
+            // Tier 1: this session's own document, which is already in memory from the load at the
+            // top of the request and survives instance restarts and scale-out. Replayed turns hit
+            // here, which is what makes hydration cost O(this turn) rather than O(conversation).
+            if (sessionCache.TryGetValue(movieId, out var cachedForSession))
+            {
+                lock (movieItems)
+                {
+                    movieItems.Add(cachedForSession);
+                }
+                return;
+            }
+
+            // Tier 2: the process-wide IDistributedCache. Shared across sessions on this instance,
+            // but AddDistributedMemoryCache means it is cold on every new instance.
             var dataInBytes = await cache.GetAsync(movieId);
             if (dataInBytes != null)
             {
                 var movieViewModel = JsonSerializer.Deserialize<MovieViewModel>(dataInBytes);
                 if (movieViewModel != null)
                 {
+                    sessionCache[movieId] = movieViewModel;
                     lock (movieItems) // Thread-safe access to shared list
                     {
                         movieItems.Add(movieViewModel);
@@ -345,6 +459,8 @@ namespace MovieTracker.Backend.Functions
                     trailerInfo
                 );
 
+                sessionCache[movieId] = movieViewModel;
+
                 lock (movieItems) // Thread-safe access to shared list
                 {
                     movieItems.Add(movieViewModel);
@@ -353,6 +469,190 @@ namespace MovieTracker.Backend.Functions
                 var movieViewModelBytes = JsonSerializer.SerializeToUtf8Bytes(movieViewModel);
                 await cache.SetAsync(movieId, movieViewModelBytes);
             }
+        }
+
+        // Turns one stored conversation message into the frontend shape, hydrating any movie ids it
+        // carries. Returns null for the messages the contract does not surface: the system prompt and
+        // the intermediate function-call / function-result messages, which have no text.
+        private async Task<ChatMessage?> ToClientMessageAsync(
+            AIChatMessage message,
+            TMDbClient client,
+            ConcurrentDictionary<string, MovieViewModel> sessionCache)
+        {
+            var text = message.Text;
+            if (string.IsNullOrEmpty(text))
+            {
+                return null;
+            }
+
+            if (message.Role == ChatRole.User)
+            {
+                return new UserChatMessage(text);
+            }
+
+            if (message.Role != ChatRole.Assistant)
+            {
+                return null;
+            }
+
+            text = text.Replace("```json", "").Replace("```", "");
+            List<MovieViewModel> movieItems = new List<MovieViewModel>();
+
+            try
+            {
+                JsonDocument doc = JsonDocument.Parse(text);
+                var root = doc.RootElement;
+                var systemMessage = root.GetProperty("SystemMessage").GetString();
+
+                if (root.TryGetProperty("MovieList", out JsonElement movieList))
+                {
+                    var tasks = new List<Task>();
+                    foreach (var movie in movieList.EnumerateArray())
+                    {
+                        tasks.Add(SafeProcessMovieAsync(movie, movieItems, client, sessionCache));
+                    }
+
+                    await Task.WhenAll(tasks);
+                }
+
+                return new AssistantChatMessage(systemMessage, movieItems);
+            }
+            catch (JsonException)
+            {
+                return new AssistantChatMessage("No movies were found", movieItems);
+            }
+        }
+
+        // Decorative, and now racing the model call rather than blocking it, so a Wikipedia outage
+        // must not take the turn down with it. Swallowing here also keeps the task from faulting
+        // while nothing is awaiting it, which the sequential version could not produce.
+        private async Task<string?> SafeGenerateFunnyFactAsync(string input)
+        {
+            try
+            {
+                return await chatPlanner.GenerateEnhancedFunnyFact(input);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Funny fact generation failed; answering without one");
+                return null;
+            }
+        }
+
+        // Azure Monitor's token metrics on the Cognitive Services account report 0 and the OpenTelemetry
+        // gen_ai.usage spans arrive only partially, so per-turn usage is logged here where it can be
+        // read straight out of App Insights. CachedInput is the one to watch: non-zero means the static
+        // system prompt, tool schemas and JSON schema are hitting Azure OpenAI's automatic prompt cache;
+        // a persistent zero means something started varying that prefix and the discount is being lost.
+        private void LogUsage(AgentResponse result)
+        {
+            if (result.Usage is not { } usage)
+            {
+                return;
+            }
+
+            logger.LogInformation(
+                "Chat-Ask usage: input={InputTokens} cachedInput={CachedInputTokens} output={OutputTokens} reasoning={ReasoningTokens} total={TotalTokens}",
+                usage.InputTokenCount,
+                usage.CachedInputTokenCount,
+                usage.OutputTokenCount,
+                usage.ReasoningTokenCount,
+                usage.TotalTokenCount);
+        }
+
+        private static ConcurrentDictionary<string, MovieViewModel> LoadHydrationCache(MoviceTrackerChatSession session) =>
+            session.HydratedMovies is null
+                ? new ConcurrentDictionary<string, MovieViewModel>()
+                : new ConcurrentDictionary<string, MovieViewModel>(session.HydratedMovies);
+
+        private async Task SaveSessionAsync(MoviceTrackerChatSession session, ConcurrentDictionary<string, MovieViewModel> sessionCache)
+        {
+            if (sessionCache.Count > HydratedMovieLimit)
+            {
+                // Only a document-size bound. Anything dropped is re-fetched from TMDb the next time
+                // it is replayed, so this costs latency on a very long conversation, never correctness.
+                logger.LogInformation(
+                    "Hydration cache for session {ChatId} holds {Count} movies; trimming to {Limit}",
+                    session.id, sessionCache.Count, HydratedMovieLimit);
+            }
+
+            session.HydratedMovies = sessionCache
+                .Take(HydratedMovieLimit)
+                .ToDictionary(entry => entry.Key, entry => entry.Value);
+
+            await chatSessionRepository.SaveChatSession(session);
+        }
+
+        // One conversational turn, shared by both routes: they differ only in how much of the
+        // conversation they hydrate afterwards. Appends the user message and everything the model
+        // produced onto the session's stored history and returns the final assistant message.
+        private async Task<AIChatMessage?> RunTurnAsync(MoviceTrackerChatSession chatSession, string input)
+        {
+            var chatMessages = chatSession.ChatHistory;
+
+            // The funny fact reads nothing but the user's raw input, yet it used to run to completion
+            // before the model call even started - an entity-detection completion, a Wikipedia REST
+            // fetch, a Wikidata SPARQL query and a second completion, all on the critical path. Kicked
+            // off here and collected after the answer comes back.
+            Task<string?> funnyFactTask = SafeGenerateFunnyFactAsync(input);
+
+            chatMessages.Add(new AIChatMessage(ChatRole.User, input));
+
+            // The agent already carries the tool set and invokes tools automatically, so only the
+            // per-call settings are built here. Run options are merged over the agent's defaults,
+            // and tool collections are unioned rather than replaced.
+            ChatOptions chatOptions = new()
+            {
+                ResponseFormat = MovieListResponseFormat,
+            };
+
+            if (!string.IsNullOrWhiteSpace(reasoningEffort)
+                && !string.Equals(reasoningEffort, "default", StringComparison.OrdinalIgnoreCase))
+            {
+                // Deliberately not ChatOptions.Reasoning: its ReasoningEffort enum only offers
+                // None/Low/Medium/High/ExtraHigh, and this setting has to be able to carry
+                // model-family-specific values such as "minimal". Dropping to the provider's own
+                // options type keeps the passthrough behaviour SK had.
+                // OPENAI001 gates ReasoningEffortLevel as evaluation-only, the same way SKEXP0010
+                // gated the structured-output ResponseFormat this method used to set.
+#pragma warning disable OPENAI001
+                chatOptions.RawRepresentationFactory = _ => new OpenAI.Chat.ChatCompletionOptions
+                {
+                    ReasoningEffortLevel = new OpenAI.Chat.ChatReasoningEffortLevel(reasoningEffort)
+                };
+#pragma warning restore OPENAI001
+            }
+
+            // Reduced over a copy on purpose. The reducer materialises whatever it is handed into the
+            // list its strategies then rewrite in place, and the stored history has to survive intact -
+            // if compaction reached it, the /ask transcript would quietly start losing turns.
+            var modelMessages = (await ContextReducer.ReduceAsync([.. chatMessages], default)).ToList();
+
+            logger.LogInformation(
+                "Chat-Ask context: sending {IncludedMessages} of {TotalMessages} stored messages to the model",
+                modelMessages.Count, chatMessages.Count);
+
+            // session: null runs the agent statelessly - the conversation is passed in on every call
+            // and the generated messages are appended back onto it. That is what the Semantic Kernel
+            // version did with a ChatHistory, and it is what lets the response be rebuilt by
+            // re-walking the stored conversation.
+            var result = await agent.RunAsync(modelMessages, null, new ChatClientAgentRunOptions(chatOptions));
+
+            LogUsage(result);
+
+            // Includes the intermediate function-call and function-result messages as well as the
+            // final answer. They carry no text, so the transcript skips them, but they must be
+            // persisted: a tool call without its result is an invalid conversation on the next turn.
+            chatMessages.AddRange(result.Messages);
+
+            var funnyFact = await funnyFactTask;
+            if (funnyFact != null)
+            {
+                chatSession.FunnyFact = funnyFact;
+            }
+
+            return result.Messages.LastOrDefault(
+                message => message.Role == ChatRole.Assistant && !string.IsNullOrEmpty(message.Text));
         }
 
         [Function("Chat-Ask")]
@@ -372,109 +672,75 @@ namespace MovieTracker.Backend.Functions
 
                 logger.LogDebug("Chat message received.");
                 var chatSession = await chatSessionRepository.GetChatSession(chatId);
-                var chatMessages = chatSession.ChatHistory;
 
-                if (chatMessages == null)
+                if (chatSession.ChatHistory == null)
                 {
                     return new BadRequestObjectResult("Chat not found");
                 }
 
-                //string? funnyFact = await chatPlanner.GenerateFunnyFact(ask.Input);
-                string? funnyFact = await chatPlanner.GenerateEnhancedFunnyFact(ask.Input);
+                var sessionCache = LoadHydrationCache(chatSession);
+                await RunTurnAsync(chatSession, ask.Input);
 
-                if (funnyFact != null)
-                {
-                    chatSession.FunnyFact = funnyFact;
-                }
-
-                chatMessages.Add(new AIChatMessage(ChatRole.User, ask.Input));
-
-                // The agent already carries the tool set and invokes tools automatically, so only the
-                // per-call settings are built here. Run options are merged over the agent's defaults,
-                // and tool collections are unioned rather than replaced.
-                ChatOptions chatOptions = new()
-                {
-                    ResponseFormat = MovieListResponseFormat,
-                };
-
-                if (!string.IsNullOrWhiteSpace(reasoningEffort)
-                    && !string.Equals(reasoningEffort, "default", StringComparison.OrdinalIgnoreCase))
-                {
-                    // Deliberately not ChatOptions.Reasoning: its ReasoningEffort enum only offers
-                    // None/Low/Medium/High/ExtraHigh, and this setting has to be able to carry
-                    // model-family-specific values such as "minimal". Dropping to the provider's own
-                    // options type keeps the passthrough behaviour SK had.
-                    // OPENAI001 gates ReasoningEffortLevel as evaluation-only, the same way SKEXP0010
-                    // gated the structured-output ResponseFormat this method used to set.
-#pragma warning disable OPENAI001
-                    chatOptions.RawRepresentationFactory = _ => new OpenAI.Chat.ChatCompletionOptions
-                    {
-                        ReasoningEffortLevel = new OpenAI.Chat.ChatReasoningEffortLevel(reasoningEffort)
-                    };
-#pragma warning restore OPENAI001
-                }
-
-                // session: null runs the agent statelessly - the entire conversation is passed in on
-                // every call and the generated messages are appended back onto it. That is exactly what
-                // the Semantic Kernel version did with a ChatHistory, and it is what lets the response
-                // below be rebuilt by re-walking the whole conversation.
-                var result = await agent.RunAsync(chatMessages, null, new ChatClientAgentRunOptions(chatOptions));
-
-                // Includes the intermediate function-call and function-result messages as well as the
-                // final answer. They carry no text, so the loop below skips them, but they must be
-                // persisted: a tool call without its result is an invalid conversation on the next turn.
-                chatMessages.AddRange(result.Messages);
-
+                // This route's contract is the whole transcript, every turn. The hydration cache is
+                // what keeps that from meaning a TMDb round trip per movie per turn.
                 var responseMessages = new List<ChatMessage>();
-                foreach (var messages in chatMessages)
+                foreach (var message in chatSession.ChatHistory)
                 {
-                    var text = messages.Text;
-                    if (messages.Role == ChatRole.Assistant && !String.IsNullOrEmpty(text))
+                    var clientMessage = await ToClientMessageAsync(message, client, sessionCache);
+                    if (clientMessage != null)
                     {
-                        text = text.Replace("```json", "").Replace("```", "");
-                        List<MovieViewModel> movieItems = new List<MovieViewModel>();
-
-                        try
-                        {
-                            System.Text.Json.JsonDocument doc = System.Text.Json.JsonDocument.Parse(text);
-                            var root = doc.RootElement;
-                            var systemMessage = root.GetProperty("SystemMessage").GetString();
-
-                            if (root.TryGetProperty("MovieList", out JsonElement movieList))
-                            {
-                                var movieListArray = movieList.EnumerateArray();
-                                var tasks = new List<Task>();
-
-                                foreach (var movie in movieListArray)
-                                {
-                                    tasks.Add(SafeProcessMovieAsync(movie, movieItems, client));
-                                }
-
-                                await Task.WhenAll(tasks);
-                            }
-
-                            AssistantChatMessage assistantChatMessage = new AssistantChatMessage(systemMessage, movieItems);
-                            responseMessages.Add(assistantChatMessage);
-                        }
-                        catch (JsonException)
-                        {
-                            var systemMessage = "No movies were found";
-                            AssistantChatMessage assistantChatMessage = new AssistantChatMessage(systemMessage, movieItems);
-                            responseMessages.Add(assistantChatMessage);
-                        }
-                    }
-
-                    if (messages.Role == ChatRole.User && !String.IsNullOrEmpty(text))
-                    {
-                        UserChatMessage userChatMessage = new UserChatMessage(text);
-                        responseMessages.Add(userChatMessage);
+                        responseMessages.Add(clientMessage);
                     }
                 }
 
-                await chatSessionRepository.UpdateChatSession(chatId, chatMessages, chatSession.FunnyFact);
+                await SaveSessionAsync(chatSession, sessionCache);
 
                 var response = new ChatMessageResponse(chatSession.FunnyFact, responseMessages);
                 return new OkObjectResult(response);
+            }
+            catch (Exception ex)
+            {
+                logger.LogCritical("{@ex}", ex);
+                return new BadRequestObjectResult(ex.Message);
+            }
+        }
+
+        // Same turn, same persistence, smaller answer: only the turn just produced is hydrated and
+        // returned. Additive - /api/chat/{chatId}/ask is untouched - and the two can be interleaved
+        // on one session, since both read and write the same stored history.
+        [Function("Chat-Ask-V2")]
+        public async Task<IActionResult> MessageV2(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "chat/{chatId}/ask/v2")] HttpRequest req,
+            string chatId)
+        {
+            using var activity = tracer.StartActiveSpan("movie-tracker-func.chat-ask-v2");
+            try
+            {
+                TMDbClient client = new TMDbClient(apiKey);
+                var ask = await req.ReadFromJsonAsync<Ask>();
+                if (ask == null)
+                {
+                    return new BadRequestObjectResult("Invalid request, missing ask object");
+                }
+
+                var chatSession = await chatSessionRepository.GetChatSession(chatId);
+
+                if (chatSession.ChatHistory == null)
+                {
+                    return new BadRequestObjectResult("Chat not found");
+                }
+
+                var sessionCache = LoadHydrationCache(chatSession);
+                var newAssistantMessage = await RunTurnAsync(chatSession, ask.Input);
+
+                ChatMessage turn = newAssistantMessage == null
+                    ? new AssistantChatMessage("No movies were found", [])
+                    : await ToClientMessageAsync(newAssistantMessage, client, sessionCache)
+                      ?? new AssistantChatMessage("No movies were found", []);
+
+                await SaveSessionAsync(chatSession, sessionCache);
+
+                return new OkObjectResult(new ChatTurnResponse(chatSession.FunnyFact, turn));
             }
             catch (Exception ex)
             {

--- a/src/MovieTracker.Backend/Program.cs
+++ b/src/MovieTracker.Backend/Program.cs
@@ -25,6 +25,12 @@ using System.ClientModel.Primitives;
 var serviceName = "movie-tracker-backend";
 var serviceVersion = "1.0.0";
 
+// FunctionInvokingChatClient allows 40 tool-calling iterations per request by default. At a few
+// seconds per round trip that exhausts the 120s HttpClient budget, and then the platform's ~230s
+// trigger limit, long before it gives up - the caller sees a timeout rather than an answer. A real
+// query needs far fewer: resolve a person, discover, fetch details, sometimes ratings.
+const int MaxToolIterations = 12;
+
 var host = new HostBuilder()
     .ConfigureAppConfiguration((context, config) =>
     {
@@ -73,7 +79,12 @@ var host = new HostBuilder()
                     options.TotalRequestTimeout.Timeout = TimeSpan.FromSeconds(120);
                     options.AttemptTimeout.Timeout = TimeSpan.FromSeconds(60);
                     options.CircuitBreaker.SamplingDuration = TimeSpan.FromSeconds(120);
-                    options.Retry.MaxRetryAttempts = 1;
+                    // The deployment is DataZoneStandard at 200K TPM and Chat-Ask now issues the
+                    // funny-fact completion and the main agent call at the same time, so bursts are
+                    // sharper than they were when the two ran back to back. The default handler already
+                    // treats 429 as transient and honours Retry-After; only the attempt budget needed
+                    // widening. TotalRequestTimeout still caps how long the retries can run.
+                    options.Retry.MaxRetryAttempts = 3;
                 });
 
         services.AddSingleton(TracerProvider.Default.GetTracer(serviceName, serviceVersion));
@@ -166,9 +177,11 @@ var host = new HostBuilder()
                 .. chatPlanner.CreateTools(),
             ];
 
+            var agentLogger = serviceProvider.GetRequiredService<ILogger<Program>>();
+
             // ChatClientAgent decorates the chat client with automatic function invocation by default,
             // which is what ToolCallBehavior.AutoInvokeKernelFunctions used to switch on.
-            return chatClient.AsAIAgent(
+            var agent = chatClient.AsAIAgent(
                 new ChatClientAgentOptions
                 {
                     Name = serviceName,
@@ -176,6 +189,32 @@ var host = new HostBuilder()
                 },
                 serviceProvider.GetRequiredService<ILoggerFactory>(),
                 serviceProvider);
+
+            // Function-invocation middleware. Wraps each individual tool call, so Iteration is the
+            // model's round-trip count within this request; Terminate ends the loop and returns what
+            // the model has produced so far, which Chat-Ask degrades gracefully on. AsBuilder().Build()
+            // returns a NEW agent - the result has to be what gets registered, or none of this runs.
+            return agent
+                .AsBuilder()
+                .Use(async (
+                    AIAgent invokedAgent,
+                    FunctionInvocationContext context,
+                    Func<FunctionInvocationContext, CancellationToken, ValueTask<object?>> next,
+                    CancellationToken cancellationToken) =>
+                {
+                    if (context.Iteration >= MaxToolIterations)
+                    {
+                        agentLogger.LogWarning(
+                            "Tool-call budget of {MaxToolIterations} iterations exhausted at {FunctionName}; ending the turn",
+                            MaxToolIterations, context.Function.Name);
+
+                        context.Terminate = true;
+                        return $"Tool-call budget exhausted. Answer with the information already gathered.";
+                    }
+
+                    return await next(context, cancellationToken);
+                })
+                .Build(serviceProvider);
         });
         services.AddOpenTelemetry()
                  .WithTracing((builder) =>

--- a/src/MovieTracker.Backend/Prompts/ChatPlanner.cs
+++ b/src/MovieTracker.Backend/Prompts/ChatPlanner.cs
@@ -29,20 +29,40 @@ namespace MovieTracker.Backend.Prompts
         }
 
         /// <summary>
-        /// Explicit tool list; see the note on TheMovieDBKernelFunctions.CreateTools. This is the same
-        /// set of methods that carried [KernelFunction] before the migration.
+        /// Explicit tool list; see the note on TheMovieDBKernelFunctions.CreateTools.
         /// </summary>
+        /// <remarks>
+        /// Four of the ten methods that carried [KernelFunction] before the migration are deliberately
+        /// no longer offered to the model. They are still called - just not by it:
+        /// <list type="bullet">
+        /// <item><description>
+        /// <see cref="GenerateEnhancedFunnyFact"/> and <see cref="GenerateFunnyFact"/> are near-duplicates
+        /// of each other, and Chat-Ask already runs the enhanced one out of band for every request. As
+        /// tools they bought nothing and cost two nested completions plus Wikipedia and Wikidata calls,
+        /// inside a tool call the model was already waiting on. The fact reaches the client through the
+        /// response's own FunnyFact field, not through the conversation.
+        /// </description></item>
+        /// <item><description>
+        /// <see cref="GenerateRequiredSteps"/> returns a fixed string restating the JSON shape, which the
+        /// system prompt states and the strict structured-output schema then enforces. A round trip to be
+        /// told something the request already guarantees.
+        /// </description></item>
+        /// <item><description>
+        /// <see cref="GetMovieRatingGeneric"/> takes the same single IMDb id as <see cref="GetMovieRating"/>
+        /// and returns the same OMDb lookup with IMDb as the primary rating. Two descriptions for one
+        /// capability is just an ambiguous choice for the model to get wrong.
+        /// </description></item>
+        /// </list>
+        /// The date helpers in <see cref="DateTimeKernelFunctions"/> were left alone on purpose: their
+        /// schemas are tiny, and they exist precisely to stop the model inventing date ranges.
+        /// </remarks>
         public IEnumerable<AITool> CreateTools() =>
         [
             AIFunctionFactory.Create(HandleTrailerRequest),
             AIFunctionFactory.Create(GetMovieRating),
             AIFunctionFactory.Create(CompareMovieRatings),
             AIFunctionFactory.Create(FilterMoviesByRating),
-            AIFunctionFactory.Create(GetMovieRatingGeneric),
-            AIFunctionFactory.Create(GenerateEnhancedFunnyFact),
             AIFunctionFactory.Create(GetChatContext),
-            AIFunctionFactory.Create(GenerateFunnyFact),
-            AIFunctionFactory.Create(GenerateRequiredSteps),
             AIFunctionFactory.Create(GetMovieContext),
         ];
 
@@ -57,7 +77,16 @@ namespace MovieTracker.Backend.Prompts
             return await GenerateRequiredSteps();
         }
 
-        [Description("Get movie rating (defaults to IMDb rating) for a specific movie using its IMDb ID. Always returns IMDb rating as the primary rating.")]
+        // Absorbs the description GetMovieRatingGeneric used to carry, since that near-duplicate tool is
+        // no longer offered: the "user said rating without naming a source" case is the whole reason it
+        // existed, and IMDb-as-default is a deliberate choice for this app rather than an accident.
+        // The last sentence is load-bearing - without it the model will happily answer a rating question
+        // from a TMDb vote average already sitting in context instead of looking the rating up.
+        [Description("Get a movie's rating from its IMDb ID. Use this whenever the user asks about a rating, " +
+                     "score or 'which was highest rated' without naming a source: IMDb is the default rating. " +
+                     "Always returns the IMDb rating as the primary rating, with Rotten Tomatoes and Metacritic " +
+                     "as secondary context only. Prefer calling this over quoting any TMDb vote average that " +
+                     "appeared in earlier search or detail results.")]
         [return: Description("JSON object containing IMDb rating as the primary rating, with other ratings as additional context")]
         public async Task<string> GetMovieRating(
             [Description("The IMDb ID of the movie (e.g., 'tt1375666')")] string imdbId)

--- a/src/MovieTracker.Backend/Prompts/TheMovieDBKernelFunctions.cs
+++ b/src/MovieTracker.Backend/Prompts/TheMovieDBKernelFunctions.cs
@@ -294,7 +294,10 @@ namespace MovieTracker.Backend.Prompts
                 Genres = movie.Genres.Select(g => g.Name).ToList(),
                 Runtime = movie.Runtime,
                 Tagline = movie.Tagline,
-                Rating = movie.VoteAverage,
+                // Named for what it is. Called "Rating" this reads as *the* rating, and the model
+                // would answer "which had the highest rating?" straight from it instead of calling
+                // GetMovieRating - which is the IMDb-backed answer this app treats as the default.
+                TmdbVoteAverage = movie.VoteAverage,
                 Language = movie.OriginalLanguage,
                 ImdbId = movie.ImdbId ?? "",
                 Cast = (await client.GetMovieCreditsAsync(movie.Id))?.Cast.Take(5).Select(c => c.Name).ToList() // Top 5 cast members


### PR DESCRIPTION
Implements the feasible recommendations from `guide.md`. **The existing `/ask` contract is unchanged** — same route, same response shape, same DTOs. `/ask/v2` is a new, purely additive route.

## New API surface: `POST /api/chat/{chatId}/ask/v2`

The only addition to the public surface. **Nothing existing changed** — `GET /api/chat/start` and `POST /api/chat/{chatId}/ask` behave exactly as before, byte-for-byte.

### Why it exists

`/ask` returns the **entire conversation** on every call. By turn 4 the client is re-receiving three turns it already has, and the server is re-hydrating every movie in them from TMDb to build that payload. Both the response size and the work behind it grow with conversation length, for data the client already holds.

`/ask/v2` returns **only the turn just produced**.

### Request — identical to v1

```
POST /api/chat/{chatId}/ask/v2
Content-Type: application/json

{ "Input": "what movies did Tom Hanks do in the 90s?" }
```

### Response

```jsonc
{
  "funnyFact": "Tom Hanks owns over 250 vintage typewriters!",
  "turn": {
    "role": "assistant",
    "text": "Tom Hanks owned the 90s...",
    "movieList": [ /* MovieViewModel, same 17 fields as v1 */ ]
  }
}
```

Compared with v1's `{ funnyFact, messages: [...] }`:

| | `/ask` | `/ask/v2` |
|---|---|---|
| Payload key | `messages` — every turn so far | `turn` — one message object |
| Movie hydration | every movie in every past turn | only the new turn's |
| Grows with conversation length | yes | no |
| `funnyFact` | unchanged | unchanged |
| Message/movie field names | unchanged | **identical** — same `role`/`text`/`movieList`, same `MovieViewModel` |

### Client notes

- **`turn` is a single object, not an array.** It uses the same polymorphic `role` discriminator as v1's messages, so an existing message renderer works on it unchanged.
- **The client owns transcript state.** v2 assumes you append each returned `turn` to what you already have. If the client discards history on reload, keep using v1 — or call v1 once to rehydrate, then continue on v2.
- **The two interleave freely on one session.** Both run the same turn logic and write the same stored history, so you can migrate incrementally, or call v1 on page load and v2 for subsequent asks. Verified in testing.
- **The user's own message is not echoed back** — the client already has it.
- Errors are unchanged: `400` with a plain-text body.

Server-side, both routes share `RunTurnAsync`; they differ only in how much of the conversation they hydrate afterwards.

## Everything else

| Area | Change |
|---|---|
| Latency | Funny fact now runs **concurrently** with the main model call instead of before it |
| Latency / TMDb | Hydrated `MovieViewModel`s **persisted in the Cosmos session doc**; hydration is now O(new turn), not O(conversation) |
| Latency | Save the loaded document directly — drops one Cosmos round trip per ask |
| Context | **Compaction** of what is sent to the model, while the full history stays stored for the transcript |
| Tools | 27 → **23**; tool-calling loop capped at 12 iterations (default is 40) |
| Resilience | Retry budget 1 → 3, since two model calls now fire together against a 200K TPM deployment |
| Ratings | IMDb-as-default made explicit in the prompt; `DescribeMovie`'s misleading `Rating` field renamed |
| Observability | Per-turn token usage incl. `cachedInput`, plus how much history compaction sent |

## Three findings worth reviewing

**The guide's central code sample does not compile.** `InMemoryChatHistoryProvider` and `MessageCountingChatReducer` do not exist in Microsoft.Agents.AI 1.15.0. What does exist — and the guide never mentions — is the `Microsoft.Agents.AI.Compaction` namespace, which suits this app better because its `CompactionMessageIndex` groups an assistant tool call with its results atomically. That is the invariant that makes trimming safe. It is gated behind `MAAI001` (evaluation-only), so this is now the one preview API the project depends on.

**The compaction default would have been near-useless here.** `ToolResultCompactionStrategy`'s built-in formatter inlines every tool result verbatim — fine for `"Sunny and 72°F"`, worthless for a 20-movie `DiscoverMovies` array. Measured on a synthetic six-turn conversation it reduced context by **3%**. A custom `ToolCallFormatter` that truncates results gets **68%** (41% at two turns, 90% at thirty).

**A rating regression that turned out to be pre-existing.** After the tool pruning, a follow-up answered from a TMDb vote average rather than IMDb — which this repo deliberately fixed in 44e6073. Rather than assume I had caused it, I A/B'd against baseline: **3/6 correct before, 5/6 after the pruning**. So it was pre-existing nondeterminism, improved rather than introduced. I then closed it properly — the system prompt never mentioned IMDb at all, and `DescribeMovie` was returning TMDb's vote average under the bare name `Rating`. After renaming it to `TmdbVoteAverage` and adding a ratings block to the prompt: **6/6**.

## Verification

Run against the live Cosmos / TMDb / OMDb / Foundry backends via `func start`:

- `/ask` response shape byte-identical — `funnyFact, messages` / `role, text, movieList` / all 17 movie fields
- Multi-turn follow-ups still resolve across compaction ("which of those had the highest rating?", "and which was most recent?")
- Stored history keeps growing (2 → 4 → 6 → 8 messages) — compaction never reaches what is persisted
- Hydration cache confirmed by reading the live Cosmos document: `HydratedMovies: 5 movies`, overviews and trailers round-tripping, `PartitionKey` casing intact
- `/ask/v2` works and interleaves with v1 on the same session; trailers still render
- A standalone harness asserts compaction safety at 1/2/3/6/15/30 turns: system message preserved, every user question and assistant answer preserved inside the window, tool calls never separated from their results, caller's list never mutated

Same-session latency A/B measured (n=7 per arm): **single turn −18%** with non-overlapping ranges, **4-turn conversation −16%** (noisier). `/ask/v2` cuts bytes over a four-turn conversation by **72%** and the final response by **93%**. Full numbers and caveats in the comment below.

## Deliberately not implemented

- **Responses API** — the guide's own analysis is that it reduces payload but not billed tokens or TPM
- **Streaming / Workflows / A2A / AG-UI / Durable** — the guide's own "don't bother" list
- **Consolidating the date helpers** — the guide says there are ten; there are seven, their schemas are tiny, and they exist to stop the model inventing date ranges. With no test suite, that behavioural change could not be A/B'd honestly.

Note the system prompt is stored per session at `/start`, so the ratings fix applies to **new sessions only**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
