### PR TITLE
Filter person credits by genre, so genre-qualified director questions work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,11 @@ The seven date helpers were kept on purpose: their schemas are tiny and they exi
 | "what has X been in" | `GetPersonMovieCredits(personId)` — no job filter |
 | person **combined with** genre/date/rating filters | `DiscoverMovies(castIds:)` or `(crewIds:)` |
 
+**Two upstream traps found by stress-testing the tool surface, both of which produce confidently wrong answers:**
+
+- **`job` is not a raw TMDb crew job.** The model naturally passes `job=Actor` for "his movies" — but acting is not a crew job in TMDb, so an exact crew-only match returns **zero** and the question dies. It also passes `job=Writer`, while TMDb spreads writing across `Writer`, `Screenplay` and `Story`. `ResolveJobFilter` maps job words onto cast-vs-crew and onto every spelling TMDb uses; unrecognised values fall through as an exact crew match so the long tail still works.
+- **TMDb's `with_runtime` filter contradicts TMDb's own runtime field.** Measured: `with_runtime.gte=181` returned Spider-Man (121 min), Interstellar (169) and Fellowship of the Ring (179) — **six of the first ten results violated the filter**, because it matches alternate release cuts. `DiscoverMovies` therefore uses it only to narrow, then re-checks every result against the canonical runtime and drops the rest. Do not remove that verification pass; without it "under two hours" returns 124-minute films.
+
 `GetPersonMovieCredits` sorts by popularity where it exists and falls back to release date. Only `MovieRole` (cast) carries `Popularity`; `MovieJob` (crew) does not. That split is deliberate: sorting acting credits by date makes "what has Meg Ryan been in?" lead with her most recent obscure work instead of *When Harry Met Sally*, while a job-filtered crew list is short and complete so newest-first is fine. Capped at `MaxPersonCredits` (25) with the withheld count stated in the payload rather than truncated silently.
 
 One thing that looks like a bug and is not: a person's credits can contain the same title twice with **different TMDb ids** — Tarantino has *Reservoir Dogs* as both `500` (1992 feature) and `443129` (1991 short), and *From Dusk Till Dawn* as `755` and `1623134`. Both are real upstream records. They are not deduplicated, because collapsing by title would silently drop a genuine credit.
@@ -249,6 +254,7 @@ What is emitted:
 | `chat <model>`, `orchestrate_tools`, `execute_tool <name>` spans | framework, free | inspecting a single turn; `execute_tool` carries `ActivityStatusCode.Error` when a tool throws |
 | `gen_ai.client.token.usage`, `gen_ai.client.operation.duration` | framework, free | token totals and model latency — unsampled |
 | `gen_ai.client.tool.duration` / `.invocations` | `InstrumentedAIFunction` | per-tool latency and failure rate, dimensioned by tool name + outcome |
+| `MovieTracker.Backend.ToolCalls` log category | `InstrumentedAIFunction` | **which tool the model chose and what it passed** — the only way to debug tool selection |
 | `chat.turn.tool_calls`, `chat.context.retained_ratio` | `Function.cs` | is the iteration cap biting; is compaction still saving anything |
 | `gen_ai.usage.cost_usd` | `Telemetry.RecordCost` | spend — **only if** the price keys below are configured |
 
@@ -266,5 +272,14 @@ Two optional configuration keys, neither provisioned by Bicep:
 |---|---|
 | `Telemetry:Enable-Sensitive-Data` | Defaults to **true**, which is the long-standing behaviour: prompts and completions appear in traces. Set `false` to stop sending user questions and model answers to App Insights. |
 | `AzureOpenAi:Price-Input-Per-1M`, `-Output-`, `-Cached-Input-` | Enables `gen_ai.usage.cost_usd`. Deliberately has **no defaults** — a hardcoded rate that drifts produces a confident, wrong cost dashboard. Cached input is charged at its own rate and subtracted from the input count, which matters here because ~80% of input tokens are cache reads. |
+
+**Debugging a wrong answer starts with `MovieTracker.Backend.ToolCalls`.** Metrics tell you `DiscoverMovies` ran twice; only this tells you one ran with a cast filter and the other with a crew filter, which is the difference between right and wrong. The framework's `execute_tool` spans carry arguments too but are sampled away, so they cannot be relied on. Nearly every tool-selection bug found so far was invisible until the arguments were logged — `job=Actor` returning nothing, a raw `"show me the trailer for that one"` reaching a tool that cannot see the conversation, a runtime constraint the model passed correctly that TMDb then ignored. It is gated on `Telemetry:Enable-Sensitive-Data` because arguments contain user-supplied names and titles:
+
+```kusto
+traces | where timestamp > ago(30m)
+| extend cat = tostring(customDimensions.CategoryName)
+| where cat == 'MovieTracker.Backend.ToolCalls'
+| project timestamp, message | order by timestamp asc
+```
 
 Worker logs do not appear in `func start` console output; read them in App Insights. Custom metrics land in the `customMetrics` table, but to be *alertable* in Metrics explorer they are published under the hardcoded namespace `azure.applicationinsights` scoped to the Application Insights resource, not the linked Log Analytics workspace — and a newly emitted metric can take 10–15 minutes to appear in metric definitions. Keep metric dimensions to low-arity values (tool name, outcome, model); Azure Monitor caps a metric at 5,000 time series per 24h and replaces all dimension values with `Maximum values reached` past that, so chat ids and movie ids belong on spans, never on metrics.

--- a/src/MovieTracker.Backend/Agents/TrailerAgent.cs
+++ b/src/MovieTracker.Backend/Agents/TrailerAgent.cs
@@ -1,108 +1,84 @@
-﻿using Microsoft.Extensions.AI;
-using Microsoft.Extensions.Configuration;
 using System.Text.Json;
 using TMDbLib.Client;
 
 namespace MovieTracker.Backend.Agents
 {
-    public class TrailerAgent
+    /// <summary>
+    /// Resolves a movie title to its best official YouTube trailer.
+    ///
+    /// This used to take the user's raw question and run an LLM extraction prompt over it to find the
+    /// title, behind a keyword gate that decided whether the question was about trailers at all. Both
+    /// are gone, because both were solving a problem at the wrong layer:
+    ///
+    /// - The extraction prompt only ever saw the single string handed to the tool, never the
+    ///   conversation. So "show me the trailer for that one", immediately after the assistant named
+    ///   The Dark Knight, extracted UNKNOWN and apologised - the model knew the referent and was told
+    ///   to discard it. The caller resolves the title now, which is the only layer that can.
+    /// - The keyword gate ("does this contain the word trailer?") was guessing at intent that the model
+    ///   has already decided by choosing to call this at all. It also fired on "show me Tom Hanks
+    ///   movies" until it was tightened.
+    ///
+    /// Dropping them removes a completion from the critical path and the IChatClient dependency with it.
+    /// </summary>
+    public class TrailerAgent(TMDbClient tmdbClient)
     {
-        private readonly TMDbClient tmdbClient;
-
-        // The bare IChatClient, deliberately not the AIAgent: this is a single-shot extraction prompt
-        // that must not inherit the agent's tool set or its JSON response format. Under Semantic
-        // Kernel this was kernel.GetRequiredService<IChatCompletionService>() called with no
-        // execution settings, which had the same effect.
-        private readonly IChatClient chatClient;
-
-        // Words that mean "video content" on their own and nothing else.
-        private static readonly string[] TrailerNouns = {
-            "trailer", "teaser", "preview", "promo", "featurette", "attraction video"
-        };
-
-        // These only count when paired with one of the nouns below. The list used to include "watch",
-        // "play" and "show" as standalone triggers, which fired on a large share of perfectly ordinary
-        // queries - "show me Tom Hanks movies" routed a plain filmography question into a trailer
-        // lookup: an extra completion to extract a title, a TMDb search and a videos call, and an
-        // apology string when it found nothing.
-        private static readonly string[] PlaybackVerbs = { "watch", "play", "show", "see" };
-        private static readonly string[] VideoNouns = { "video", "footage", "clip" };
-
-        public TrailerAgent(TMDbClient tmdbClient, IChatClient chatClient)
+        public async Task<string> GetTrailerForTitle(string movieTitle)
         {
-            this.tmdbClient = tmdbClient;
-            this.chatClient = chatClient;
-        }
+            var title = movieTitle?.Trim();
 
-        public bool CanHandle(string userQuery)
-        {
-            if (string.IsNullOrWhiteSpace(userQuery)) return false;
-
-            if (TrailerNouns.Any(noun => userQuery.Contains(noun, StringComparison.OrdinalIgnoreCase)))
+            if (string.IsNullOrWhiteSpace(title) || title.Equals("UNKNOWN", StringComparison.OrdinalIgnoreCase))
             {
-                return true;
+                return JsonSerializer.Serialize(new
+                {
+                    Error = "No movie title was supplied.",
+                    Hint = "Pass the film's title. If the user referred to it indirectly - 'that one', "
+                         + "'it' - use the title from earlier in the conversation; this tool cannot see it."
+                });
             }
 
-            // "watch the video", "play that clip" - the verb alone is not evidence of anything.
-            return PlaybackVerbs.Any(verb => userQuery.Contains(verb, StringComparison.OrdinalIgnoreCase))
-                && VideoNouns.Any(noun => userQuery.Contains(noun, StringComparison.OrdinalIgnoreCase));
-        }
+            var searchResults = await tmdbClient.SearchMovieAsync(title);
+            var match = searchResults.Results.FirstOrDefault();
 
-        public async Task<string> HandleRequest(string userQuery)
-        {
-            var movieTitle = await ExtractMovieTitle(userQuery);
-            if (string.IsNullOrWhiteSpace(movieTitle))
-                return "Sorry, I couldn't determine which movie you want a trailer for.";
+            if (match is null)
+            {
+                return JsonSerializer.Serialize(new
+                {
+                    Error = $"No movie found matching '{title}'.",
+                    Hint = "Check the title, or call SearchMovies to find the right one first."
+                });
+            }
 
-            var movieId = await SearchForMovie(movieTitle);
-            if (string.IsNullOrWhiteSpace(movieId))
-                return $"Sorry, I couldn't find a movie titled '{movieTitle}'.";
+            var videos = await tmdbClient.GetMovieVideosAsync(match.Id);
 
-            var trailerUrl = await GetTrailerUrl(movieId);
-            if (string.IsNullOrWhiteSpace(trailerUrl))
-                return $"Sorry, a trailer for '{movieTitle}' could not be found.";
-
-            return $"[TRAILER]{trailerUrl}[/TRAILER]";
-        }
-
-        private async Task<string> ExtractMovieTitle(string userQuery)
-        {
-            var prompt = $@"
-                Extract the movie title from: '{userQuery}'
-                Return ONLY the movie title, or 'UNKNOWN' if no specific movie is mentioned.
-                
-                Examples:
-                'show me the batman trailer' -> 'The Batman'
-                'play inception trailer' -> 'Inception'
-                'trailer please' -> 'UNKNOWN'
-                ";
-
-            var result = await chatClient.GetResponseAsync(prompt);
-            var movieTitle = result.Text?.Trim();
-
-            return movieTitle?.ToUpper() == "UNKNOWN" ? "" : movieTitle ?? "";
-        }
-
-        private async Task<string> SearchForMovie(string movieTitle)
-        {
-            var searchResults = await tmdbClient.SearchMovieAsync(movieTitle);
-
-            return searchResults.Results.FirstOrDefault()?.Id.ToString() ?? "";
-        }
-
-        private async Task<string> GetTrailerUrl(string movieId)
-        {
-            var videos = await tmdbClient.GetMovieVideosAsync(int.Parse(movieId));
-
-            // Same ordering as ProcessMovieAsync in Function.cs, size included. Without the size tie-break
-            // the two paths could pick different trailers for the same film.
+            // Same ordering as ProcessMovieAsync in Function.cs, size included. Without the size
+            // tie-break the two paths could pick different trailers for the same film.
             var trailer = videos.Results
-                .Where(v => v.Type == "Trailer" && v.Site == "YouTube")
-                .OrderByDescending(v => v.Official)
-                .ThenByDescending(v => v.Size)
+                .Where(video => video.Type == "Trailer" && video.Site == "YouTube")
+                .OrderByDescending(video => video.Official)
+                .ThenByDescending(video => video.Size)
                 .FirstOrDefault();
 
-            return trailer != null ? $"https://www.youtube.com/watch?v={trailer.Key}" : "";
+            if (trailer is null)
+            {
+                return JsonSerializer.Serialize(new
+                {
+                    MovieId = match.Id.ToString(),
+                    MovieName = match.Title,
+                    Error = $"No YouTube trailer is available for '{match.Title}'.",
+                    Hint = "Say so plainly rather than substituting a different film's trailer."
+                });
+            }
+
+            return JsonSerializer.Serialize(new
+            {
+                MovieId = match.Id.ToString(),
+                MovieName = match.Title,
+                ReleaseDate = match.ReleaseDate?.ToString("yyyy-MM-dd") ?? "",
+                TrailerName = trailer.Name,
+                // The system prompt requires this wrapper in SystemMessage for the frontend to render
+                // the player inline, so it is handed over pre-wrapped rather than described.
+                EmbedInSystemMessage = $"[TRAILER]https://www.youtube.com/watch?v={trailer.Key}[/TRAILER]"
+            });
         }
     }
 }

--- a/src/MovieTracker.Backend/Functions/Function.cs
+++ b/src/MovieTracker.Backend/Functions/Function.cs
@@ -419,8 +419,23 @@ namespace MovieTracker.Backend.Functions
                       results yourself. Use genreMatch "any" for "X or Y" and leave it out for "X and Y".
                     - Populate MovieList with every relevant movie you found. Return an empty MovieList only
                       when the functions genuinely came back with no matches.
+                    - Every entry in MovieList must be a film that actually answers the question. If the
+                      answer is about people rather than films - "who played Batman", "who directed this" -
+                      return an empty MovieList and put the answer in SystemMessage. Never pad it with an
+                      actor's unrelated filmography just to have something there.
+                    - If you have looked something up several times and still cannot answer, say so in
+                      SystemMessage with an empty MovieList. A short honest answer beats a padded one.
                     - Order MovieList deliberately - best or most relevant first, and in the same order you
                       discuss them in SystemMessage. That order is preserved all the way to the user.
+                    - Superlatives ("longest", "highest rated", "newest", "biggest") mean comparing the
+                      actual numbers a function returned, across every result. Function results are not
+                      sorted by whatever the question asks for, so the first entry is not the answer -
+                      read the values and pick the winner. If you say one number beats another, check
+                      that it actually does.
+                    - Anything about children, families or age-appropriateness: pass maxCertification to
+                      DiscoverMovies ("PG" or "PG-13") rather than deciding yourself whether a film is
+                      suitable. You will get it wrong - and recommending an R-rated film for family night
+                      is worse than returning fewer titles.
                     - MovieIds, PersonIds, genre ids and IMDb ids are plumbing. Use them in function calls
                       and put them in MovieList, but never mention one in SystemMessage - the user reads
                       that text and "Christopher Nolan (TMDb PersonId 525)" means nothing to them.
@@ -436,7 +451,12 @@ namespace MovieTracker.Backend.Functions
                       function result into SystemMessage - the user sees that text verbatim.
 
                     **If the user requests a trailer, preview, teaser, promo, or attraction video, always include the trailer's YouTube link in your response, embedded in-line and wrapped in [TRAILER]...[/TRAILER] tags.**
-                    For example: [TRAILER]https://www.youtube.com/watch?v=vc7_mH2PWHs[/TRAILER]
+                    The link goes inside the tags exactly as a tool returned it, like
+                    [TRAILER]{the youtube.com URL HandleTrailerRequest or GetMovieTrailers gave you}[/TRAILER].
+                    - NEVER write a [TRAILER] block containing a URL you did not just receive from a tool.
+                      Do not reuse a URL from earlier in the conversation for a different film, and do not
+                      reproduce any example URL. A wrong trailer plays the wrong movie for the user.
+                    - Only include a [TRAILER] block when the user actually asked for one.
 
                     Your response must always be a JSON object with these properties:
                     - "SystemMessage": A rich, engaging message (2-4 sentences) that's informative yet entertaining. Use enthusiastic but not over-the-top language. Include interesting details, trivia, or context that makes the movie sound compelling. **If a trailer is available, embed the trailer link in-line using [TRAILER]...[/TRAILER] tags.**
@@ -445,7 +465,7 @@ namespace MovieTracker.Backend.Functions
                     Examples of good SystemMessage responses:
                     - "Inception is Nolan's mind-bending masterpiece where dreams have dreams! The rotating hallway fight took 3 weeks to film and Leonardo DiCaprio's spinning top became one of cinema's most iconic props."
                     - "The Matrix revolutionized action cinema with its bullet-time effects and deep philosophical themes. Keanu Reeves trained for 4 months to perform his own stunts, and the green 'code' is actually Japanese sushi recipes!"
-                    - "The Batman (2022) reimagines Gotham with a gritty noir style. [TRAILER]https://www.youtube.com/watch?v=vc7_mH2PWHs[/TRAILER]"
+                    - "The Batman (2022) reimagines Gotham with a gritty noir style. [TRAILER]{the URL the trailer tool returned}[/TRAILER]"
 
                     If no specific movies are found, provide helpful search suggestions in an engaging way:
                     {

--- a/src/MovieTracker.Backend/Functions/Function.cs
+++ b/src/MovieTracker.Backend/Functions/Function.cs
@@ -408,6 +408,9 @@ namespace MovieTracker.Backend.Functions
                       the PersonId, and pass job="Director" for directing. It is the only tool that knows
                       which job someone did on a film - a plain crew filter also matches writing,
                       producing, even a "Thanks" credit, and cast filters miss directors entirely.
+                    - If the question also names a genre ("sci-fi films X directed"), pass genreIds to
+                      GetPersonMovieCredits too. Do not ask for the whole filmography and filter it
+                      yourself: that returns every film they made and costs a lookup per title.
                     - Use DiscoverMovies castIds/crewIds when you need to combine a person with other
                       filters (genre, dates, rating); use GetPersonMovieCredits when the question is
                       about one person's own work.

--- a/src/MovieTracker.Backend/Program.cs
+++ b/src/MovieTracker.Backend/Program.cs
@@ -295,8 +295,16 @@ var host = new HostBuilder()
                 .. DateTimeKernelFunctions.CreateTools(),
                 .. chatPlanner.CreateTools(),
             ];
+            // The logger is what makes tool *selection* debuggable. Metrics say DiscoverMovies ran twice;
+            // only this says whether it ran with a cast filter or a crew filter, which is the difference
+            // between a right and a wrong answer. Its own category so it can be turned down on its own.
+            var toolLogger = serviceProvider.GetRequiredService<ILoggerFactory>()
+                .CreateLogger("MovieTracker.Backend.ToolCalls");
+
             tools = [.. tools.Select(tool =>
-                tool is AIFunction function ? new InstrumentedAIFunction(function) : tool)];
+                tool is AIFunction function
+                    ? new InstrumentedAIFunction(function, toolLogger, enableSensitiveTelemetry)
+                    : tool)];
 
             // ChatClientAgent decorates the chat client with automatic function invocation by default,
             // which is what ToolCallBehavior.AutoInvokeKernelFunctions used to switch on. The

--- a/src/MovieTracker.Backend/Prompts/ChatPlanner.cs
+++ b/src/MovieTracker.Backend/Prompts/ChatPlanner.cs
@@ -59,28 +59,14 @@ namespace MovieTracker.Backend.Prompts
             AIFunctionFactory.Create(GetMovieContext),
         ];
 
-        [Description("Handle a request for a movie trailer and return a clickable trailer link. " +
-                     "Only call this when the user actually asked for a trailer, teaser, preview or promo.")]
+        [Description("Get a movie's trailer link from its title. Call this when the user asks for a " +
+                     "trailer, teaser, preview or promo. Returns the [TRAILER]...[/TRAILER] string to " +
+                     "embed in SystemMessage.")]
         public async Task<string> HandleTrailerRequest(
-            [Description("The user's request, verbatim")] string userQuery)
-        {
-            if (trailerAgent.CanHandle(userQuery))
-            {
-                return await trailerAgent.HandleRequest(userQuery);
-            }
-
-            // Used to return GenerateRequiredSteps(), a restatement of the response schema whose worked
-            // example contained "MovieId": "1" - a fabricated id of exactly the kind the system prompt
-            // forbids - plus an ImdbId field that DisallowAdditionalProperties rejects. Handing that to
-            // the model mid-conversation taught it the wrong shape. Same {Error, Hint} envelope the TMDb
-            // tools use for a correctable mistake.
-            return JsonSerializer.Serialize(new
-            {
-                Error = "That does not look like a trailer request, so no trailer was looked up.",
-                Hint = "Answer the question with the movie search tools instead. Only call " +
-                       "HandleTrailerRequest when the user asks for a trailer, teaser, preview or promo."
-            });
-        }
+            [Description("The film's title. Resolve any reference yourself first - if the user said " +
+                         "'that one' or 'it', pass the title you named earlier in the conversation. " +
+                         "This tool cannot see the conversation, only this argument.")] string movieTitle)
+            => await trailerAgent.GetTrailerForTitle(movieTitle);
 
         // Absorbs the description GetMovieRatingGeneric used to carry, since that near-duplicate tool is
         // no longer offered: the "user said rating without naming a source" case is the whole reason it

--- a/src/MovieTracker.Backend/Prompts/TheMovieDBKernelFunctions.cs
+++ b/src/MovieTracker.Backend/Prompts/TheMovieDBKernelFunctions.cs
@@ -27,6 +27,14 @@ namespace MovieTracker.Backend.Prompts
         private const int MaxPersonCredits = 25;
 
         /// <summary>
+        /// How many credits to look up genres for when a genre filter is supplied. The filter has to run
+        /// before the cap - filtering the top 25 by popularity would miss a qualifying film that sits at
+        /// 30 - so the candidate pool is widened first. Only paid when genreIds is actually passed, and
+        /// still bounded: a director's whole filmography fits comfortably inside this.
+        /// </summary>
+        private const int MaxGenreFilterLookups = 60;
+
+        /// <summary>
         /// Resolves TMDb movie ids to IMDb ids, concurrently, bounded by
         /// <see cref="MaxConcurrentTmdbCalls"/>.
         /// <para>
@@ -64,6 +72,51 @@ namespace MovieTracker.Backend.Prompts
             }));
 
             return new Dictionary<int, string>(resolved);
+        }
+
+        /// <summary>What a per-movie detail lookup contributes beyond the credit itself.</summary>
+        private sealed record MovieFacts(string ImdbId, IReadOnlyList<int> GenreIds, IReadOnlyList<string> GenreNames);
+
+        /// <summary>
+        /// Like <see cref="ResolveImdbIdsAsync"/> but fetches the whole movie, because TMDb's person
+        /// credits carry no genre at all on crew entries - <c>MovieJob</c> has Title, Job and dates and
+        /// nothing else, so "sci-fi films X directed" cannot be answered from the credits list alone.
+        /// <para>
+        /// This is the same <i>number</i> of round trips as resolving external ids: one per movie either
+        /// way, bounded by <see cref="MaxConcurrentTmdbCalls"/>. GetMovieAsync just returns more from
+        /// each of them, including the ImdbId that lookup existed for. The lighter external-ids path is
+        /// kept for search and discover, which need no genres.
+        /// </para>
+        /// </summary>
+        private async Task<Dictionary<int, MovieFacts>> ResolveMovieFactsAsync(IEnumerable<int> movieIds)
+        {
+            var resolved = new ConcurrentDictionary<int, MovieFacts>();
+            using var throttle = new SemaphoreSlim(MaxConcurrentTmdbCalls);
+
+            await Task.WhenAll(movieIds.Distinct().Select(async movieId =>
+            {
+                await throttle.WaitAsync();
+                try
+                {
+                    var movie = await client.GetMovieAsync(movieId);
+                    resolved[movieId] = new MovieFacts(
+                        movie.ImdbId ?? "",
+                        [.. movie.Genres?.Select(genre => genre.Id) ?? []],
+                        [.. movie.Genres?.Select(genre => genre.Name).Where(name => name is not null) ?? []]);
+                }
+                catch
+                {
+                    // A movie we cannot describe still belongs in the list under its own title; it just
+                    // cannot participate in genre filtering.
+                    resolved[movieId] = new MovieFacts("", [], []);
+                }
+                finally
+                {
+                    throttle.Release();
+                }
+            }));
+
+            return new Dictionary<int, MovieFacts>(resolved);
         }
 
         /// <summary>
@@ -202,14 +255,19 @@ namespace MovieTracker.Backend.Prompts
                      "each film. This is the right tool for 'what did X direct', 'what did X write' and " +
                      "'what has X been in', because it is the only one that can tell a directing credit " +
                      "from a writing or producing one - pass job='Director' for 'directed by'. Prefer " +
-                     "this over DiscoverMovies(crewIds:) for any question about one person's own work.")]
-        [return: Description("JSON with the person's credits: MovieId, MovieName, ReleaseDate, ImdbId, and either Character (acting) or Job")]
+                     "this over DiscoverMovies(crewIds:) for any question about one person's own work. " +
+                     "For 'sci-fi films X directed', pass genreIds as well and let this filter them; the " +
+                     "returned credits also carry Genres so you can narrow further yourself.")]
+        [return: Description("JSON with the person's credits: MovieId, MovieName, ReleaseDate, ImdbId, Genres, and either Character (acting) or Job")]
         public async Task<string> GetPersonMovieCredits(
             [Description("The TMDb PersonId, as returned by SearchForPeople")] string personId,
             [Description("Optional: keep only credits with this exact job, e.g. 'Director', 'Screenplay', " +
                          "'Producer'. Use 'Director' for 'directed by'. Omit for acting roles plus all crew work.")] string? job = null,
             [Description("Optional: only films released in or after this year (YYYY)")] string? fromYear = null,
-            [Description("Optional: only films released in or before this year (YYYY)")] string? toYear = null)
+            [Description("Optional: only films released in or before this year (YYYY)")] string? toYear = null,
+            [Description("Optional: keep only films in these genres, as comma-separated genre ids from " +
+                         "GetGenresList. Use this for 'sci-fi films X directed' rather than filtering the " +
+                         "results yourself - a person's credits do not otherwise carry genres.")] string? genreIds = null)
         {
             if (!TryGetPersonId(personId, out var tmdbPersonId, out var idError)) return idError;
 
@@ -266,9 +324,15 @@ namespace MovieTracker.Backend.Prompts
                 .ThenByDescending(credit => credit.Date)
                 .ToList();
 
-            var capped = all.Take(MaxPersonCredits).ToList();
+            var wantGenres = string.IsNullOrEmpty(genreIds) ? [] : ParseIdList(genreIds);
+            var filterByGenre = wantGenres.Count > 0;
 
-            // Resolve the IMDb ids here rather than telling the model to go and fetch them.
+            // Genre filtering has to happen before the cap, so widen the candidate pool when one is
+            // asked for - filtering the top 25 by popularity would silently miss a qualifying film
+            // sitting at position 30.
+            var candidates = all.Take(filterByGenre ? MaxGenreFilterLookups : MaxPersonCredits).ToList();
+
+            // Resolve details here rather than telling the model to go and fetch them.
             //
             // The first version of this method omitted ImdbId and pointed the model at DescribeMovie,
             // reasoning that skipping the fan-out was cheaper. Measured on the deployed app, it was the
@@ -276,29 +340,43 @@ namespace MovieTracker.Backend.Prompts
             // went from a max of 3 to a max of 10 against a cap of 12. The N+1 had not gone away, it had
             // moved from HTTP round trips into *model* iterations - roughly 1s each instead of 40ms, and
             // charged against the iteration budget, where running out truncates the answer.
-            var imdbIds = await ResolveImdbIdsAsync(
-                capped.Select(credit => int.TryParse(credit.MovieId, out var id) ? id : 0).Where(id => id > 0));
+            var facts = await ResolveMovieFactsAsync(
+                candidates.Select(credit => int.TryParse(credit.MovieId, out var id) ? id : 0).Where(id => id > 0));
 
-            var shown = capped.Select(credit => new
+            static MovieFacts FactsFor(Dictionary<int, MovieFacts> lookup, string movieId) =>
+                int.TryParse(movieId, out var id) && lookup.TryGetValue(id, out var found)
+                    ? found
+                    : new MovieFacts("", [], []);
+
+            var matching = filterByGenre
+                ? candidates.Where(credit => FactsFor(facts, credit.MovieId).GenreIds.Intersect(wantGenres).Any()).ToList()
+                : candidates;
+
+            var shown = matching.Take(MaxPersonCredits).Select(credit => new
             {
                 credit.MovieId,
                 credit.MovieName,
                 credit.ReleaseDate,
                 credit.Credit,
-                ImdbId = int.TryParse(credit.MovieId, out var id) && imdbIds.TryGetValue(id, out var imdb) ? imdb : "",
+                FactsFor(facts, credit.MovieId).ImdbId,
+                // Carried even when no filter was applied: it lets the model narrow the list itself for
+                // anything the genre ids cannot express ("his war films", "something funny").
+                Genres = FactsFor(facts, credit.MovieId).GenreNames,
             }).ToList();
 
             return JsonSerializer.Serialize(new
             {
                 PersonId = personId,
                 JobFilter = filterByJob ? wantJob : "(none - acting and all crew credits)",
-                TotalMatching = all.Count,
+                GenreFilter = filterByGenre ? genreIds : "(none)",
+                TotalCredits = all.Count,
+                TotalMatching = matching.Count,
                 Returned = shown.Count,
                 Credits = shown,
                 // Say so rather than silently truncating, so the model does not present a capped list
                 // as a complete filmography.
-                Note = all.Count > shown.Count
-                    ? $"Showing {shown.Count} of {all.Count} matching credits, best known first."
+                Note = matching.Count > shown.Count
+                    ? $"Showing {shown.Count} of {matching.Count} matching credits, best known first."
                     : "Complete list for this filter.",
                 Hint = "ImdbId is included - pass it straight to GetMovieRating or CompareMovieRatings. "
                      + "No need to call DescribeMovie first."

--- a/src/MovieTracker.Backend/Prompts/TheMovieDBKernelFunctions.cs
+++ b/src/MovieTracker.Backend/Prompts/TheMovieDBKernelFunctions.cs
@@ -8,7 +8,12 @@ using TMDbLib.Objects.Discover;
 
 namespace MovieTracker.Backend.Prompts
 {
-    public record MovieSearchResult(string MovieId, string MovieName, string ReleaseDate, string ImdbId);
+    public record MovieSearchResult(
+        string MovieId,
+        string MovieName,
+        string ReleaseDate,
+        string ImdbId,
+        int? RuntimeMinutes = null);
     public record GenresItem(string GenreId, string GenreName);
 
     public class TheMovieDBKernelFunctions(TMDbClient client)
@@ -33,6 +38,12 @@ namespace MovieTracker.Backend.Prompts
         /// still bounded: a director's whole filmography fits comfortably inside this.
         /// </summary>
         private const int MaxGenreFilterLookups = 60;
+
+        /// <summary>
+        /// TMDb keys content ratings by country and there is no global one. US is hardcoded to match the
+        /// rest of the app, which already assumes an English-language, US-centric catalogue.
+        /// </summary>
+        private const string CertificationCountry = "US";
 
         /// <summary>
         /// Resolves TMDb movie ids to IMDb ids, concurrently, bounded by
@@ -75,7 +86,11 @@ namespace MovieTracker.Backend.Prompts
         }
 
         /// <summary>What a per-movie detail lookup contributes beyond the credit itself.</summary>
-        private sealed record MovieFacts(string ImdbId, IReadOnlyList<int> GenreIds, IReadOnlyList<string> GenreNames);
+        private sealed record MovieFacts(
+            string ImdbId,
+            IReadOnlyList<int> GenreIds,
+            IReadOnlyList<string> GenreNames,
+            int? Runtime);
 
         /// <summary>
         /// Like <see cref="ResolveImdbIdsAsync"/> but fetches the whole movie, because TMDb's person
@@ -102,13 +117,14 @@ namespace MovieTracker.Backend.Prompts
                     resolved[movieId] = new MovieFacts(
                         movie.ImdbId ?? "",
                         [.. movie.Genres?.Select(genre => genre.Id) ?? []],
-                        [.. movie.Genres?.Select(genre => genre.Name).Where(name => name is not null) ?? []]);
+                        [.. movie.Genres?.Select(genre => genre.Name).Where(name => name is not null) ?? []],
+                        movie.Runtime);
                 }
                 catch
                 {
                     // A movie we cannot describe still belongs in the list under its own title; it just
                     // cannot participate in genre filtering.
-                    resolved[movieId] = new MovieFacts("", [], []);
+                    resolved[movieId] = new MovieFacts("", [], [], null);
                 }
                 finally
                 {
@@ -261,13 +277,18 @@ namespace MovieTracker.Backend.Prompts
         [return: Description("JSON with the person's credits: MovieId, MovieName, ReleaseDate, ImdbId, Genres, and either Character (acting) or Job")]
         public async Task<string> GetPersonMovieCredits(
             [Description("The TMDb PersonId, as returned by SearchForPeople")] string personId,
-            [Description("Optional: keep only credits with this exact job, e.g. 'Director', 'Screenplay', " +
-                         "'Producer'. Use 'Director' for 'directed by'. Omit for acting roles plus all crew work.")] string? job = null,
+            [Description("Optional: keep only credits of this kind. 'Director' for 'directed by', " +
+                         "'Writer' for 'wrote', 'Producer' for 'produced', 'Actor' for 'starred in'. " +
+                         "Omit for acting roles plus all crew work.")] string? job = null,
             [Description("Optional: only films released in or after this year (YYYY)")] string? fromYear = null,
             [Description("Optional: only films released in or before this year (YYYY)")] string? toYear = null,
             [Description("Optional: keep only films in these genres, as comma-separated genre ids from " +
                          "GetGenresList. Use this for 'sci-fi films X directed' rather than filtering the " +
-                         "results yourself - a person's credits do not otherwise carry genres.")] string? genreIds = null)
+                         "results yourself - a person's credits do not otherwise carry genres.")] string? genreIds = null,
+            [Description("Optional: how to order the credits. 'popularity' (default, best known first), " +
+                         "'longest' or 'shortest' by runtime, 'newest' or 'oldest' by release date. For " +
+                         "'the longest film X directed' pass 'longest' and take the first result - do not " +
+                         "ask for the default order and compare the runtimes yourself.")] string? sortBy = null)
         {
             if (!TryGetPersonId(personId, out var tmdbPersonId, out var idError)) return idError;
 
@@ -276,9 +297,17 @@ namespace MovieTracker.Backend.Prompts
             var wantJob = job?.Trim();
             var filterByJob = !string.IsNullOrEmpty(wantJob);
 
-            // Acting credits are only relevant when no crew job was asked for - "what did Nolan direct"
-            // should not come back with his cameos.
-            var acting = filterByJob
+            var (jobKind, jobNames) = filterByJob
+                ? ResolveJobFilter(wantJob!)
+                : (CreditKind.Crew, []);
+
+            // Acting credits are excluded when a *crew* job was asked for - "what did Nolan direct"
+            // should not come back with his cameos - but they are the whole answer when the job asked
+            // for is an acting one.
+            var includeCast = !filterByJob || jobKind == CreditKind.Cast;
+            var includeCrew = !filterByJob || jobKind == CreditKind.Crew;
+
+            var acting = !includeCast
                 ? []
                 : (credits.Cast ?? []).Select(role => new
                 {
@@ -290,8 +319,9 @@ namespace MovieTracker.Backend.Prompts
                     Popularity = (double?)role.Popularity,
                 }).ToList();
 
-            var working = (credits.Crew ?? [])
-                .Where(crew => !filterByJob || string.Equals(crew.Job, wantJob, StringComparison.OrdinalIgnoreCase))
+            var working = (!includeCrew ? [] : (credits.Crew ?? []))
+                .Where(crew => !filterByJob
+                    || jobNames.Contains(crew.Job ?? string.Empty, StringComparer.OrdinalIgnoreCase))
                 .Select(crew => new
                 {
                     MovieId = crew.Id.ToString(),
@@ -327,10 +357,15 @@ namespace MovieTracker.Backend.Prompts
             var wantGenres = string.IsNullOrEmpty(genreIds) ? [] : ParseIdList(genreIds);
             var filterByGenre = wantGenres.Count > 0;
 
-            // Genre filtering has to happen before the cap, so widen the candidate pool when one is
-            // asked for - filtering the top 25 by popularity would silently miss a qualifying film
-            // sitting at position 30.
-            var candidates = all.Take(filterByGenre ? MaxGenreFilterLookups : MaxPersonCredits).ToList();
+            var order = sortBy?.Trim().ToLowerInvariant();
+            // Runtime is only known after the detail lookup below, so a runtime sort has to see more
+            // than the final 25 - same reason genre filtering does.
+            var sortNeedsRuntime = order is "longest" or "shortest";
+
+            // Genre filtering and runtime sorting both have to happen before the cap, so widen the
+            // candidate pool when either is asked for - filtering or sorting the top 25 by popularity
+            // would silently miss a qualifying film sitting at position 30.
+            var candidates = all.Take(filterByGenre || sortNeedsRuntime ? MaxGenreFilterLookups : MaxPersonCredits).ToList();
 
             // Resolve details here rather than telling the model to go and fetch them.
             //
@@ -346,11 +381,27 @@ namespace MovieTracker.Backend.Prompts
             static MovieFacts FactsFor(Dictionary<int, MovieFacts> lookup, string movieId) =>
                 int.TryParse(movieId, out var id) && lookup.TryGetValue(id, out var found)
                     ? found
-                    : new MovieFacts("", [], []);
+                    : new MovieFacts("", [], [], null);
 
             var matching = filterByGenre
                 ? candidates.Where(credit => FactsFor(facts, credit.MovieId).GenreIds.Intersect(wantGenres).Any()).ToList()
                 : candidates;
+
+            // Sorting here rather than leaving the model to compare. Asked for Nolan's longest film with
+            // the runtimes sitting in front of it, gpt-5.4-mini repeatedly answered "The Odyssey at 173
+            // minutes, which edges out Oppenheimer by 8 minutes" - it computed the gap correctly and
+            // attributed it backwards, anchoring on whichever title came first. Ordering in code makes
+            // the answer the first element instead of an arithmetic exercise.
+            matching = order switch
+            {
+                "longest" => [.. matching.OrderByDescending(c => FactsFor(facts, c.MovieId).Runtime ?? 0)],
+                "shortest" => [.. matching
+                    .Where(c => FactsFor(facts, c.MovieId).Runtime is > 0)
+                    .OrderBy(c => FactsFor(facts, c.MovieId).Runtime)],
+                "newest" => [.. matching.OrderByDescending(c => c.Date)],
+                "oldest" => [.. matching.Where(c => c.Date > DateTime.MinValue).OrderBy(c => c.Date)],
+                _ => matching,
+            };
 
             var shown = matching.Take(MaxPersonCredits).Select(credit => new
             {
@@ -362,6 +413,11 @@ namespace MovieTracker.Backend.Prompts
                 // Carried even when no filter was applied: it lets the model narrow the list itself for
                 // anything the genre ids cannot express ("his war films", "something funny").
                 Genres = FactsFor(facts, credit.MovieId).GenreNames,
+                // Free - the detail lookup above already returned it. Without it "the longest film X
+                // directed" cannot be answered from this payload, and the model guesses a likely title
+                // and verifies only that one: asked for Nolan's longest it answered The Odyssey (173
+                // min) having never looked at Oppenheimer (181).
+                RuntimeMinutes = FactsFor(facts, credit.MovieId).Runtime,
             }).ToList();
 
             return JsonSerializer.Serialize(new
@@ -369,6 +425,7 @@ namespace MovieTracker.Backend.Prompts
                 PersonId = personId,
                 JobFilter = filterByJob ? wantJob : "(none - acting and all crew credits)",
                 GenreFilter = filterByGenre ? genreIds : "(none)",
+                SortedBy = order is "longest" or "shortest" or "newest" or "oldest" ? order : "popularity",
                 TotalCredits = all.Count,
                 TotalMatching = matching.Count,
                 Returned = shown.Count,
@@ -382,6 +439,45 @@ namespace MovieTracker.Backend.Prompts
                      + "No need to call DescribeMovie first."
             });
         }
+
+        /// <summary>Whether a job word refers to on-screen work or behind-the-camera work.</summary>
+        private enum CreditKind { Cast, Crew }
+
+        /// <summary>
+        /// Maps the job word the model supplies onto how TMDb actually credits it.
+        /// <para>
+        /// Two failures made this necessary, both caught by logging the arguments the model really
+        /// passed. First, <c>job=Actor</c>: acting is not a crew job in TMDb, so a naive crew-only
+        /// filter dropped the cast list *and* matched nothing, returning zero credits for "the worst
+        /// rated Adam Sandler movie" - a question about an actor's films. Second, <c>job=Writer</c>:
+        /// TMDb spreads writing across Writer, Screenplay and Story, so an exact match silently loses
+        /// whichever spelling a given film happens to use. Both are the obvious thing for a model to
+        /// pass, so both have to work.
+        /// </para>
+        /// <para>
+        /// An unrecognised value falls through as an exact crew-job match, which keeps the tool usable
+        /// for the long tail ("Costume Design") without needing a table of every TMDb job.
+        /// </para>
+        /// </summary>
+        private static (CreditKind Kind, string[] Jobs) ResolveJobFilter(string job) =>
+            job.Trim().ToLowerInvariant() switch
+            {
+                "actor" or "actress" or "acting" or "cast" or "star" or "starring" or "self"
+                    => (CreditKind.Cast, []),
+                "director" or "directed" or "directing" or "filmmaker"
+                    => (CreditKind.Crew, ["Director"]),
+                "writer" or "writing" or "written" or "screenwriter" or "screenplay" or "author"
+                    => (CreditKind.Crew, ["Writer", "Screenplay", "Story", "Author"]),
+                "producer" or "produced" or "producing"
+                    => (CreditKind.Crew, ["Producer", "Executive Producer", "Co-Producer", "Associate Producer"]),
+                "composer" or "music"
+                    => (CreditKind.Crew, ["Original Music Composer", "Composer", "Music"]),
+                "cinematographer" or "cinematography"
+                    => (CreditKind.Crew, ["Director of Photography", "Cinematography"]),
+                "editor" or "editing"
+                    => (CreditKind.Crew, ["Editor", "Film Editor"]),
+                _ => (CreditKind.Crew, [job.Trim()]),
+            };
 
         /// <summary>Year-bounds filter that treats an unparseable or absent year as "no bound".</summary>
         private static bool WithinYears(DateTime? releaseDate, string? fromYear, string? toYear)
@@ -573,10 +669,11 @@ namespace MovieTracker.Backend.Prompts
         }
 
         [Description("Get full details for one movie by its TMDb MovieId: overview, release date, genres " +
-                     "(with ids), runtime, tagline, language, top-billed cast, poster art and the ImdbId. " +
-                     "This is the single movie-detail tool - use it whenever you need more about a film " +
-                     "than a search result carries. For the rating, call GetMovieRating with the ImdbId " +
-                     "this returns.")]
+                     "(with ids), runtime, tagline, language, top-billed cast, poster art, worldwide box " +
+                     "office and budget, and the ImdbId. This is the single movie-detail tool - use it " +
+                     "whenever you need more about a film than a search result carries, including 'how " +
+                     "much did it make' and 'who was in it'. For the rating, call GetMovieRating with the " +
+                     "ImdbId this returns.")]
         [return: Description("Serialized JSON containing information about a specific movie including ImdbId")]
         public async Task<string> DescribeMovie([Description("The movie ID of a specific movie")] string movieId)
         {
@@ -606,6 +703,12 @@ namespace MovieTracker.Backend.Prompts
                 ImdbId = movie.ImdbId ?? "",
                 PosterPath = movie.PosterPath,
                 BackdropPath = movie.BackdropPath,
+                // Worldwide, in USD, straight off the movie record this call already fetched. Asked what
+                // Titanic made, the model previously had nowhere to get this and answered from memory
+                // via a Wikipedia context call. OMDb's BoxOffice is US-domestic only, so it is not a
+                // substitute for the figure people mean.
+                WorldwideRevenueUsd = movie.Revenue,
+                BudgetUsd = movie.Budget,
                 Cast = movie.Credits?.Cast?.Take(5).Select(c => c.Name).ToList() // Top 5 cast members
             };
 
@@ -665,7 +768,15 @@ namespace MovieTracker.Backend.Prompts
                        "orders by the TMDb vote average, which is not the IMDb rating: to answer a rating " +
                        "question, still call GetMovieRating or CompareMovieRatings on the results.")] string? sortBy = null,
           [Description("Optional: 'all' (default) requires a movie to match every genre id supplied; " +
-                       "'any' matches at least one. Use 'any' for 'action or comedy'.")] string? genreMatch = null
+                       "'any' matches at least one. Use 'any' for 'action or comedy'.")] string? genreMatch = null,
+          [Description("Optional: US content rating ceiling - 'G', 'PG', 'PG-13', 'R' or 'NC-17'. " +
+                       "Returns only films rated at or below it. Use this for anything about kids, " +
+                       "families or age-appropriateness; do not judge a film's rating yourself.")] string? maxCertification = null,
+          [Description("Optional: exact US content rating, e.g. 'PG-13'. Prefer maxCertification unless " +
+                       "the user asked for precisely one rating.")] string? certification = null,
+          [Description("Optional: longest runtime in minutes. Use this for 'under two hours' or " +
+                       "'something short' instead of fetching each film to check.")] int? maxRuntimeMinutes = null,
+          [Description("Optional: shortest runtime in minutes, for 'a proper long epic'.")] int? minRuntimeMinutes = null
       )
         {
             DiscoverMovie query = client.DiscoverMoviesAsync();
@@ -744,6 +855,35 @@ namespace MovieTracker.Backend.Prompts
                 }
             }
 
+            // Content rating. Without this the model had no way to honour "PG-13" or "for the kids", so
+            // it approximated with genre ids and its own sense of what is family-safe - and got it
+            // wrong: asked for PG-13 family movie night it returned The Matrix, which is rated R, and
+            // said it was not "full hard-R". TMDb keys certifications by country and only US is wired
+            // up here, which is the same assumption the rest of the app already makes.
+            if (!string.IsNullOrWhiteSpace(maxCertification))
+            {
+                query = query.WhereCertificationIsAtMost(CertificationCountry, maxCertification.Trim().ToUpperInvariant());
+            }
+
+            if (!string.IsNullOrWhiteSpace(certification))
+            {
+                query = query.WhereCertificationIs(CertificationCountry, certification.Trim().ToUpperInvariant());
+            }
+
+            // Runtime. Without these, "a 70s horror film under two hours" ran an unfiltered discover and
+            // then spent five DescribeMovie calls checking runtimes one at a time - the same N+1 through
+            // the model that GetPersonMovieCredits used to cause, and it still let a 122-minute film
+            // through. TMDb can answer this in the same request.
+            if (maxRuntimeMinutes is > 0)
+            {
+                query = query.WhereRuntimeIsAtMost(maxRuntimeMinutes.Value);
+            }
+
+            if (minRuntimeMinutes is > 0)
+            {
+                query = query.WhereRuntimeIsAtLeast(minRuntimeMinutes.Value);
+            }
+
             // Apply vote average filters
             if (minVoteAverage.HasValue)
             {
@@ -768,6 +908,7 @@ namespace MovieTracker.Backend.Prompts
 
             // Execute query and get results with IMDb IDs
             var searchResults = await query.Query();
+            var wantsRuntimeFilter = maxRuntimeMinutes is > 0 || minRuntimeMinutes is > 0;
 
             // A bare "[]" tells the model nothing about why, and an empty lookup is precisely the moment
             // it stops calling functions and starts answering from memory. Filtering a director as cast
@@ -782,6 +923,40 @@ namespace MovieTracker.Backend.Prompts
                     Hint = "No movies matched those cast ids. If the person is a director, writer or "
                          + "producer rather than an actor, pass their PersonId as crewIds instead of "
                          + "castIds and try again. Do not answer from memory."
+                });
+            }
+
+            // TMDb's with_runtime cannot be trusted, so it is used to narrow the set and then verified
+            // here. Measured against the live API: with_runtime.gte=181 returned Spider-Man (121 min),
+            // Interstellar (169) and Fellowship of the Ring (179) - six of the first ten results
+            // contradicted TMDb's *own* runtime field, because the filter matches alternate release cuts
+            // rather than the canonical runtime. Sending that back unchecked is how "under two hours"
+            // came back with a 124-minute film.
+            if (wantsRuntimeFilter)
+            {
+                var facts = await ResolveMovieFactsAsync(searchResults.Results.Select(movie => movie.Id));
+
+                var verified = searchResults.Results
+                    .Select(movie => (Movie: movie, Runtime: facts.TryGetValue(movie.Id, out var f) ? f.Runtime : null))
+                    // An unknown runtime cannot be shown to satisfy the constraint, so it is dropped
+                    // rather than assumed to pass.
+                    .Where(entry => entry.Runtime is > 0
+                        && (maxRuntimeMinutes is not > 0 || entry.Runtime <= maxRuntimeMinutes)
+                        && (minRuntimeMinutes is not > 0 || entry.Runtime >= minRuntimeMinutes))
+                    .Select(entry => new MovieSearchResult(
+                        entry.Movie.Id.ToString(),
+                        entry.Movie.Title ?? "",
+                        entry.Movie.ReleaseDate?.ToString("yyyy-MM-dd") ?? "",
+                        facts.TryGetValue(entry.Movie.Id, out var found) ? found.ImdbId : "",
+                        entry.Runtime))
+                    .ToList();
+
+                return JsonSerializer.Serialize(new
+                {
+                    Results = verified,
+                    Note = $"{verified.Count} of {searchResults.Results.Count} results actually satisfy the "
+                         + "runtime filter; TMDb's own runtime filter is unreliable, so the rest were "
+                         + "verified and dropped here. RuntimeMinutes is the checked value.",
                 });
             }
 

--- a/src/MovieTracker.Backend/Telemetry.cs
+++ b/src/MovieTracker.Backend/Telemetry.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
 
 namespace MovieTracker.Backend;
 
@@ -139,7 +140,10 @@ internal static class Telemetry
 /// Deliberately emits no Activity: the framework already opens an
 /// <c>execute_tool &lt;name&gt;</c> span around this call.
 /// </summary>
-internal sealed class InstrumentedAIFunction(AIFunction inner) : DelegatingAIFunction(inner)
+internal sealed class InstrumentedAIFunction(
+    AIFunction inner,
+    ILogger? logger = null,
+    bool logArguments = false) : DelegatingAIFunction(inner)
 {
     protected override async ValueTask<object?> InvokeCoreAsync(
         AIFunctionArguments arguments, CancellationToken cancellationToken)
@@ -149,15 +153,72 @@ internal sealed class InstrumentedAIFunction(AIFunction inner) : DelegatingAIFun
         {
             var result = await base.InvokeCoreAsync(arguments, cancellationToken);
             Telemetry.RecordTool(Name, stopwatch.Elapsed, succeeded: true);
+            LogCall(arguments, stopwatch.Elapsed, error: null);
             return result;
         }
-        catch
+        catch (Exception ex)
         {
             // Rethrown untouched. The framework catches it, records it on its own execute_tool span,
             // and hands the model a correctable error - which several tools here rely on.
             Telemetry.RecordTool(Name, stopwatch.Elapsed, succeeded: false);
+            LogCall(arguments, stopwatch.Elapsed, ex);
             throw;
         }
+    }
+
+    /// <summary>
+    /// Which tool the model chose and what it passed.
+    /// <para>
+    /// The metrics above give counts and durations but not arguments, and the framework's
+    /// <c>execute_tool</c> spans - which do carry them - are sampled away: host.json enables adaptive
+    /// sampling and a spot check found 5 surviving spans against 107 real calls. So when an answer is
+    /// wrong there is otherwise no way to see *why*, and tool-selection bugs live almost entirely in
+    /// the arguments: a director filtered as cast, a job filter applied to a question that wanted
+    /// acting credits, a genre the model decided to apply itself instead of passing down.
+    /// </para>
+    /// <para>
+    /// Gated on <c>Telemetry:Enable-Sensitive-Data</c>, because arguments contain the names and titles
+    /// the user asked about. Names only when that is off.
+    /// </para>
+    /// </summary>
+    private void LogCall(AIFunctionArguments arguments, TimeSpan elapsed, Exception? error)
+    {
+        if (logger is null || !logger.IsEnabled(LogLevel.Information))
+        {
+            return;
+        }
+
+        var rendered = logArguments ? Render(arguments) : "(arguments not logged)";
+
+        if (error is null)
+        {
+            logger.LogInformation("tool {ToolName}({ToolArguments}) ok in {ElapsedMs}ms",
+                Name, rendered, (int)elapsed.TotalMilliseconds);
+        }
+        else
+        {
+            logger.LogWarning("tool {ToolName}({ToolArguments}) FAILED in {ElapsedMs}ms: {Error}",
+                Name, rendered, (int)elapsed.TotalMilliseconds, error.Message);
+        }
+    }
+
+    private const int MaxLoggedArgumentChars = 120;
+
+    private static string Render(AIFunctionArguments arguments)
+    {
+        if (arguments is null || arguments.Count == 0) return string.Empty;
+
+        return string.Join(", ", arguments
+            .Where(argument => argument.Value is not null)
+            .Select(argument =>
+            {
+                var value = argument.Value!.ToString() ?? string.Empty;
+                if (value.Length > MaxLoggedArgumentChars)
+                {
+                    value = value[..MaxLoggedArgumentChars] + "...";
+                }
+                return $"{argument.Key}={value}";
+            }));
     }
 }
 


### PR DESCRIPTION
Follow-up to #17, from verifying it in production. One commit.

## The gap

`GetPersonMovieCredits` filters precisely by **job** but had nothing to say about **genre**, so a
genre-qualified person question returned the whole filmography and left the model to narrow it.
Production, `what sci-fi movies did Christopher Nolan direct?`:

```
Inception, Interstellar, Tenet, The Dark Knight, The Dark Knight Rises,
Batman Begins, Memento, Insomnia, Following
```

Only the first three are sci-fi.

It was also expensive. The model then called `GetMovieRating` once per title across the unfiltered
list, and `chat.turn.tool_calls` reached **12** — exactly `MaxToolIterations`, i.e. zero headroom
before a turn gets cut off mid-answer.

Worth noting how this slipped through: the check in the #17 suite asserted "no producer credits
leaked" and "Inception present", both of which passed. And the PR app happened to answer this one
correctly, so it only showed up on the production run. A single green run was hiding a
nondeterministic wrong answer.

## Why the credits list alone cannot fix it

TMDb's person-credits response has no genre on crew entries. Reflected from `TMDbLib 3.0.0`,
`MovieJob` is:

```
Adult, CreditId, Department, Id, Job, OriginalTitle, PosterPath, ReleaseDate, Title
```

No genre, no popularity. (`MovieRole`, the cast entry, does carry both — which is why the popularity
sort in #17 only applies to acting credits.)

So the genre has to come from a per-movie lookup. This method **already makes exactly one of those
per returned credit**, to resolve `ImdbId`. Switching it from `GetMovieExternalIdsAsync` to
`GetMovieAsync` is the same number of round trips, bounded by the same semaphore — it just returns
genres alongside the id that lookup existed for. Search and discover keep the lighter external-ids
path, since they need no genres.

## The change

- `genreIds` parameter, comma-separated, same convention as `DiscoverMovies`.
- `Genres` returned on **every** credit even when no filter was passed, so the model can narrow on
  things genre ids cannot express ("his war films", "something funny").
- The filter runs **before** the cap, so the candidate pool widens to `MaxGenreFilterLookups` (60)
  when filtering. Capping first would silently drop a qualifying film sitting at position 30.
- System prompt tells the model to pass `genreIds` rather than fetch everything and filter itself.

## Measured

Same suite, local, before and after:

| | before | after |
|---|---|---|
| "sci-fi Nolan directed" | 9 titles incl. *Batman Begins*, *Memento*, *Insomnia* | **5/5 runs clean** — Inception, Interstellar, Tenet, The Prestige |
| max tool calls in one turn | **12** (at the cap) | **7** |
| `GetMovieRating` calls | 10 | **0** — the model uses `CompareMovieRatings` once instead |

Full regression: **11/11**.

(*The Prestige* is genuinely tagged Science Fiction on TMDb, so it belongs there.)

## The cost, stated plainly

`GetPersonMovieCredits` goes from **132 ms to 235 ms** mean, because it now fetches full movie
records rather than external ids, and looks at more candidates when a genre filter is present.

That buys back five tool iterations, each roughly a second. More importantly it moves cost off the
**iteration budget**, where running out truncates an answer, and onto wall-clock inside a single tool
call, where it just costs time. Same reasoning as 6fe3e9d in #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
